### PR TITLE
chore: bump to v1.5.0, add changelog entry, refresh stale comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to BareLauncher land here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] — 2026-06-24
+
+The "home favourites row + pull-down app drawer" release — the biggest UX
+change since the launcher's first cut. Apple-TV / Fire-TV style banner tiles
+replace the round home-shelf icons, and a pull-down drawer holds the full app
+list. Still zero-dependency. Existing installs migrate transparently —
+favourites are seeded from the current order and ordering is unchanged.
+
+### Added
+
+- **Apple-TV / Fire-TV banner tiles.** The home shelf and the new drawer
+  render landscape 5:3 rounded-rectangle banner tiles — real `android:banner`
+  art when an app ships one, otherwise a generated icon-on-dark-plate tile —
+  sized dynamically so exactly **6 tiles fit per row on any panel width**
+  (`computeTileDims`). A new in-memory `bannerCache` / `bannerInflight`
+  pipeline mirrors the icon pipeline; tiles load lazily per visible cell so
+  cold start stays cheap (no eager decode of the whole list). The small round
+  chip icons remain on the keymap / hidden-apps surfaces (a view-level
+  circular clip over the shared `iconCache`).
+- **Pull-down app drawer.** `DPAD_DOWN` on a home cell opens a vertical
+  recycling grid of every non-hidden app; `DPAD_UP` from the top row (or
+  `BACK`) closes it. Frosted-glass backdrop via `RenderEffect` blur on
+  Android 12+, with a near-opaque grey fallback below. Drawer teardown is
+  deferred to `onResume` so launching an app from the drawer animates from the
+  drawer instead of briefly flashing the home screen.
+- **One continuous home/drawer space ("Option A").** A single flat ordered
+  list plus one `homeCount` integer (persisted under the new `home_count`
+  pref) records where the home/drawer boundary sits — the bottom favourites
+  row IS the first `homeCount` apps of the drawer order. All index math, focus
+  navigation, and the promote/demote Move rules live in the Android-free,
+  JVM-tested `HomeDrawerModel` (`COLS = 6`).
+- **`HomeDrawerModelTest`** — JVM unit tests for the drawer geometry,
+  navigation, and Option-A promote/demote Move rules.
+
+### Changed
+
+- **Unified, minimal Move flow on both surfaces.** Long-press opens the menu;
+  OK on **Move** starts moving; the D-pad then reorders (left/right on the
+  shelf; any direction in the drawer, crossing the home boundary to
+  promote/demote a favourite); OK or Back commits. The shared context menu and
+  its highlight logic now drive whichever surface is reordering through the
+  new `ReorderHost` interface, and the single icon-delivery pipeline feeds both
+  grids through the new `IconTarget` interface.
+- **Selection ring is now a rounded-rectangle halo** that hugs the banner
+  tile's corner (concentric stroke), replacing the circular ring.
+
+### Migration
+
+- `home_count` is absent on upgrade and resolves to the first `COLS` of the
+  user's **existing** stored order, so favourites are never reset.
+  `app_order` stays the single source of truth for ordering — the new key only
+  records the home/drawer split.
+
+### Housekeeping
+
+- Refreshed stale inline comments left over from the 8→6 column change and the
+  1.4.2 icon-sampling rewrite; corrected the documented focus-bounce tension.
+  No behavioural change.
+
 ## [1.4.9] — 2026-06-24
 
 Adds an About screen and reworks the clock and toolbar icons. Still

--- a/LauncherV15/app/build.gradle.kts
+++ b/LauncherV15/app/build.gradle.kts
@@ -405,8 +405,52 @@ android {
         // release QR + credit), 3-state clock (full → time-only → off) with a
         // bigger plate-less clock + day/date line, minimal floating Wi-Fi/gear
         // icons, and a touch more spacing between app tiles.
-        versionCode   = 27
-        versionName   = "1.4.9"
+        //
+        // Bumped 27 → 28: 1.5.0 is the "home favourites row + pull-down app
+        // drawer" release — the largest UX change since the launcher's first
+        // cut, and a SemVer MINOR bump (additive feature, no breaking changes,
+        // existing installs migrate transparently).
+        //
+        //   • Apple-TV / Fire-TV banner tiles. The home shelf and the new
+        //     drawer render landscape 5:3 rounded-rectangle banner tiles
+        //     (real android:banner art when an app ships one, else a
+        //     generated icon-on-dark-plate tile) sized dynamically so exactly
+        //     6 fit per row on ANY panel width (see computeTileDims). New
+        //     in-memory bannerCache / bannerInflight pipeline mirrors the icon
+        //     pipeline; lazy per-cell load (visible rows only) keeps cold
+        //     start cheap. The round chip icons stay for the keymap / hidden-
+        //     apps surfaces (view-level circular clip, shared iconCache).
+        //
+        //   • Pull-down app drawer. DPAD_DOWN on a home cell opens a vertical
+        //     recycling grid showing every (non-hidden) app; DPAD_UP from the
+        //     top row (or BACK) closes it. Frosted-glass backdrop via
+        //     RenderEffect blur on Android 12+ (near-opaque grey fallback
+        //     below). Drawer teardown is deferred to onResume so launching an
+        //     app from the drawer animates from the drawer instead of flashing
+        //     the home screen.
+        //
+        //   • One continuous home/drawer space ("Option A"). A single flat
+        //     ordered list plus one homeCount integer (persisted under the new
+        //     KEY_HOME_COUNT) records where the home/drawer boundary sits. The
+        //     bottom home favourites row IS the first homeCount apps of the
+        //     drawer order. All index math, focus navigation, and the
+        //     promote/demote Move rules live in the Android-free, JVM-tested
+        //     HomeDrawerModel (COLS = 6).
+        //
+        //   • Unified, minimal Move flow on both surfaces. Long-press → menu;
+        //     OK on Move → D-pad reorders (LEFT/RIGHT on the shelf; any
+        //     direction in the drawer, crossing the home boundary to
+        //     promote/demote); OK or BACK commits. The shared context menu and
+        //     its highlight logic drive whichever surface is reordering via the
+        //     new ReorderHost interface; the single icon-delivery pipeline
+        //     feeds both grids via the new IconTarget interface.
+        //
+        //   • Migration: KEY_HOME_COUNT is absent on upgrade and resolves to
+        //     the first COLS of the user's EXISTING stored order, so favourites
+        //     are never reset. KEY_APP_ORDER stays the single source of truth
+        //     for ordering. New unit tests: HomeDrawerModelTest.
+        versionCode   = 28
+        versionName   = "1.5.0"
         resourceConfigurations += listOf("en")
 
         // Instrumentation test runner. Required so :app:connectedDebugAndroidTest

--- a/LauncherV15/app/src/main/java/com/bare/launcher/HomeDrawerModel.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/HomeDrawerModel.java
@@ -21,7 +21,7 @@ import java.util.List;
  *       per row, showing the <em>entire</em> visible list. Its first row is
  *       the home row (the first {@code homeCount} apps, rendered centred to
  *       mirror the bottom row); the remaining apps fill rows 1+ left-aligned,
- *       8 per row, with the last (incomplete) row left-aligned.</li>
+ *       {@link #COLS} per row, with the last (incomplete) row left-aligned.</li>
  * </ul>
  *
  * <p><b>"Option A" — one continuous space.</b> Home membership is purely
@@ -68,8 +68,8 @@ final class HomeDrawerModel {
     /** Default home-row size for a brand-new install (or the first run after
      *  an upgrade where no {@code home_count} pref exists yet): the first
      *  {@link #COLS} apps, or all of them when fewer than {@link #COLS} are
-     *  installed. Mirrors the legacy "first 8 of the stored order" behaviour
-     *  so an upgrade never resets the user to alphabetical. */
+     *  installed. Mirrors the legacy "first {@link #COLS} of the stored order"
+     *  behaviour so an upgrade never resets the user to alphabetical. */
     static int defaultHomeCount(int size) {
         return Math.min(COLS, Math.max(0, size));
     }
@@ -248,7 +248,7 @@ final class HomeDrawerModel {
      *       slot the moved app just vacated. {@code homeCount} stays at
      *       {@link #COLS}.</li>
      *   <li><b>Any lower row</b>: ordinary vertical swap with the cell one row
-     *       up (8 positions earlier).</li>
+     *       up ({@link #COLS} positions earlier).</li>
      * </ul>
      */
     static <T> MoveResult moveUp(List<T> order, int index, int homeCount) {
@@ -299,7 +299,7 @@ final class HomeDrawerModel {
      *       {@code homeCount--}. (It stays in the drawer — only its home
      *       membership changes.)</li>
      *   <li><b>Any other row</b>: ordinary vertical swap with the cell one row
-     *       down (8 positions later), snapping to the nearest existing cell
+     *       down ({@link #COLS} positions later), snapping to the nearest existing cell
      *       when the row below is shorter. No-op on the last row.</li>
      * </ul>
      */

--- a/LauncherV15/app/src/main/java/com/bare/launcher/IconDiskCache.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/IconDiskCache.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  *       {@code ResolveInfo.loadIcon} / {@code PackageManager.getActivityIcon}
  *       (~5-15 ms per icon on cheap TV ROMs).</li>
  *   <li>{@link IconRenderer#process}: AdaptiveIconDrawable layering,
- *       white-plate detection via {@link Bitmap#copyPixelsToBuffer},
+ *       white-plate detection via a 12-point {@link Bitmap#getPixel} sample,
  *       circle clip + saveLayer ({@code SRC_IN}) compositing.
  *       (~5-20 ms per icon depending on icon shape.)</li>
  * </ol>

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -100,9 +100,10 @@ public class LauncherActivity extends Activity {
     private static final String KEY_APP_ORDER  = "app_order";
     /** v1.5.0: number of leading apps (in the visible / non-hidden order)
      *  that form the bottom "home favourites" row and, equivalently, the
-     *  centred first row of the pull-down app drawer. Range [0, 8]. Absent on
+     *  centred first row of the pull-down app drawer. Range [0, COLS]. Absent on
      *  first run after the v1.5.0 upgrade → resolved lazily to
-     *  {@link HomeDrawerModel#defaultHomeCount(int)} (the first 8 of the
+     *  {@link HomeDrawerModel#defaultHomeCount(int)} (the first
+     *  {@link HomeDrawerModel#COLS} of the
      *  user's EXISTING stored order) so an upgrade never resets favourites.
      *  The flat {@link #KEY_APP_ORDER} string is unchanged and stays the
      *  single source of truth for ordering; this key only records where the
@@ -913,7 +914,8 @@ public class LauncherActivity extends Activity {
      *
      *  <p>First call with a non-empty list reads the persisted value or, when
      *  absent (the v1.5.0 upgrade), falls back to
-     *  {@link HomeDrawerModel#defaultHomeCount(int)} — the first 8 of the
+     *  {@link HomeDrawerModel#defaultHomeCount(int)} — the first
+     *  {@link HomeDrawerModel#COLS} of the
      *  user's EXISTING stored order — and writes it back so the migration
      *  default sticks. Later calls only re-clamp in memory (persisting a
      *  shrink, e.g. when the user hides enough apps that the home row no
@@ -3493,7 +3495,7 @@ public class LauncherActivity extends Activity {
                             if (f && isAttachedToWindow() && getWidth() > 0)
                                 positionRing(CellView.this);
                         } else if (f) {
-                            // Subtle bouncy focus-IN: OvershootInterpolator(2.0)
+                            // Subtle bouncy focus-IN: OvershootInterpolator(2.8)
                             // ticks the cell ~7-8 % past FOCUS_SCALE then settles.
                             // Reads as a tiny "tap" of life on selection without
                             // dominating the shelf or stressing slow GPUs.


### PR DESCRIPTION
Versions the finished v1.5.0 work (home favourites row + pull-down app drawer + Apple-TV banner tiles) that had landed in code but was still tagged 1.4.9/versionCode 27.

- build.gradle.kts: versionCode 27 -> 28, versionName 1.4.9 -> 1.5.0, with a 1.5.0 summary comment block.

- CHANGELOG.md: new [1.5.0] entry (drawer, banner tiles, Option-A home/drawer model, unified Move flow, rounded-rect ring, migration notes).

- Refresh stale comments left from the 8->6 column change (HomeDrawerModel + LauncherActivity home_count docs) and the 1.4.2 icon-sampling rewrite (IconDiskCache getPixel); correct the documented focus-bounce tension (2.0 -> 2.8).

Comment/doc and version metadata only - no behavioural change.