### PR TITLE
release: v2.0.0 (versionCode 28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -792,7 +792,7 @@ across every hot-path scan we have.
   pill size — the teeth filled most of the angular budget, leaving
   little visible gap between them. The v1.3.4 6-tooth gear has a
   60° step instead of 45°, opening up wider angular gaps that read
-  as the canonical Material / iOS / tvOS settings gear at TV viewing
+  as the canonical Material settings gear at TV viewing
   distance. Per-tooth corner radius bumped from 30 % to 45 % of the
   tooth width so each tooth reads as visibly rounded rather than
   rectangular (the user's "rounded teeth" feedback). Tooth length
@@ -1049,7 +1049,7 @@ plus an audit pass that tidies a couple of small things.
 ### Audit
 
 - Removed a dead `toothW` constant inside
-  `AppleStyle.drawGearGlyph` that v1.3.0 declared "kept for design
+  `ToolbarStyle.drawGearGlyph` that v1.3.0 declared "kept for design
   intent" but didn't actually use. The unreachable
   `if (toothW < 0f)` line that prevented the unused-local-variable
   warning is gone with it.
@@ -1143,7 +1143,7 @@ and every config surface lives in one discoverable place.
   "remap remote buttons" entry — it's the unified settings entry —
   so the visual symbol updates to match. The gear is drawn entirely
   with `Canvas` primitives via the new
-  `AppleStyle.drawGearGlyph(canvas, cx, cy, r, color, stroke)`
+  `ToolbarStyle.drawGearGlyph(canvas, cx, cy, r, color, stroke)`
   helper: 8 teeth, body ring, inner hole, all proportional to the
   pill radius. No new vector or raster resources.
 - **WiFi pill long-press is now unbound.** The system-Settings
@@ -1652,7 +1652,7 @@ buffer alive for both `ImageView`s.
   first-tier WiFi shortcut. Discoverable via the standard
   press-and-hold gesture; falls back to a toast on stripped ROMs
   that have no Settings activity.
-- **`AppleStyle.makePillBackground(density)`** factory added so the
+- **`ToolbarStyle.makePillBackground(density)`** factory added so the
   clock pill and the toolbar plates draw with the same code (one
   paint set, one rounded-rect path). Each call produces a fresh
   `Drawable` because `Drawable` state (bounds / alpha / level) is
@@ -1707,7 +1707,7 @@ now converge cleanly instead of silently freezing those code paths.
   three button factories share — replaces three identical 1.06f
   literals). Color philosophy is identical: dark-glass idle plate,
   frosted-white focused plate, hairline white rim, glyph inverts on
-  focus. Every paint factory in `AppleStyle` is untouched.
+  focus. Every paint factory in `ToolbarStyle` is untouched.
 - **Mapper "sliders" glyph rebalanced for the smaller plate.** Bar
   length scales from 1.30× → 1.12× of the icon container so the bars
   no longer skim the rim, with a slightly thinner stroke (0.18 →
@@ -1866,8 +1866,8 @@ sink, and a hardened release pipeline.
     rasterisation, transparent-background detection, white-plate
     application, circle clipping). Owns its `ThreadLocal` scratch
     buffers and `Paint` instances. Allocation hygiene unchanged.
-  - `AppleStyle` — static helpers for the toolbar pill button style
-    (`applyApplePillStyle`, paint factories for stroke / fill / idle /
+  - `ToolbarStyle` — static helpers for the toolbar pill button style
+    (`applyPillStyle`, paint factories for stroke / fill / idle /
     focused / rim).
   - `KeymapStore` — pure-Java parse / serialise helpers for the
     persisted keymap and hidden-apps strings, exposed via a visitor /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to BareLauncher land here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] — 2026-06-25
+
+A big redesign. BareLauncher gets a fresh TV-style home screen and a
+pull-down app drawer — while staying the same fast, lightweight launcher
+with no ads and no tracking.
+
+### New
+
+- **Redesigned home screen.** Your favourite apps sit in a tidy row along
+  the bottom as large, easy-to-read tiles.
+- **Pull-down app drawer.** Press down on the home row to see all your
+  apps in a clean grid; press up or Back to close.
+- **Organise apps the same way everywhere.** Hold OK on any app to Move
+  it, Hide it, Uninstall it, or open its App info — on both the home row
+  and in the drawer.
+- **About screen** (in Settings) with the app version, a "Support on
+  Ko-fi" link, and a link to get the latest version — each with a QR code
+  and a tappable link that opens in your browser.
+- **Choose your clock:** full (time with day and date), time only, or off.
+
+### Improved
+
+- Cleaner floating Wi-Fi and settings icons that stay visible on any
+  wallpaper; the Wi-Fi icon now shows when you're connected.
+- Hide apps you don't want on screen, and manage them from Settings.
+- App icons stay correct after an app updates.
+- Smoother animations, plus speed and stability improvements throughout.
+
 ## [1.4.9] — 2026-06-24
 
 Adds an About screen and reworks the clock and toolbar icons. Still

--- a/LauncherV15/app/build.gradle.kts
+++ b/LauncherV15/app/build.gradle.kts
@@ -405,8 +405,24 @@ android {
         // release QR + credit), 3-state clock (full → time-only → off) with a
         // bigger plate-less clock + day/date line, minimal floating Wi-Fi/gear
         // icons, and a touch more spacing between app tiles.
-        versionCode   = 27
-        versionName   = "1.4.9"
+        //
+        // Bumped 27 → 28: 2.0.0 — the first public release of the redesigned
+        // launcher. SemVer MAJOR bump: the home screen is now an Apple-TV /
+        // Fire-TV style banner-tile favourites row with a pull-down app
+        // drawer (the legacy single-row icon shelf is gone), which is a large
+        // enough UX change to warrant a major version even though the upgrade
+        // is transparent (favourites seed from the user's existing order and
+        // KEY_APP_ORDER stays the single source of truth).
+        //
+        // Rolls up every unreleased increment since the last public tag
+        // (v1.4.7): 1.4.8 (drawer UX pass), 1.4.9 (About card + 3-state clock
+        // + floating Wi-Fi/gear icons), and the 1.5.x drawer/banner overhaul
+        // (home favourites row + pull-down drawer + banner tiles + unified
+        // Move flow), plus the About browser-link / Wi-Fi-cleanup / post-
+        // update banner-refresh pass. See CHANGELOG.md [2.0.0] for the
+        // user-facing summary.
+        versionCode   = 28
+        versionName   = "2.0.0"
         resourceConfigurations += listOf("en")
 
         // Instrumentation test runner. Required so :app:connectedDebugAndroidTest

--- a/LauncherV15/app/src/main/java/com/bare/launcher/ClockFormatter.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/ClockFormatter.java
@@ -15,7 +15,7 @@ import java.util.Locale;
  * Encapsulates the home-screen clock's text formatting.
  *
  * <p>Visual brief: system-aware wall clock — 12-hour with a small "AM/PM"
- * suffix rendered at ~42% size in {@code sans-serif-thin} (Apple-TV / iOS
+ * suffix rendered at ~42% size in {@code sans-serif-thin} (modern
  * lock-screen style) when the device is in 12-hour mode; plain "HH:MM"
  * with no suffix when the device is in 24-hour mode.  The caller obtains
  * the current preference via
@@ -131,7 +131,7 @@ final class ClockFormatter {
      *
      * <p>When {@code use24h} is {@code false} (12-hour mode): renders
      * "h:mm AM" or "h:mm PM" with the AM/PM suffix at ~42% size in
-     * {@code sans-serif-thin} — Apple-TV / iOS lock-screen style.
+     * {@code sans-serif-thin} — modern lock-screen style.
      *
      * <p>When {@code use24h} is {@code true} (24-hour mode): renders
      * "HH:MM" always two digits for the hour (00–23), no AM/PM suffix.

--- a/LauncherV15/app/src/main/java/com/bare/launcher/HomeDrawerModel.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/HomeDrawerModel.java
@@ -21,7 +21,7 @@ import java.util.List;
  *       per row, showing the <em>entire</em> visible list. Its first row is
  *       the home row (the first {@code homeCount} apps, rendered centred to
  *       mirror the bottom row); the remaining apps fill rows 1+ left-aligned,
- *       8 per row, with the last (incomplete) row left-aligned.</li>
+ *       {@link #COLS} per row, with the last (incomplete) row left-aligned.</li>
  * </ul>
  *
  * <p><b>"Option A" — one continuous space.</b> Home membership is purely
@@ -68,8 +68,8 @@ final class HomeDrawerModel {
     /** Default home-row size for a brand-new install (or the first run after
      *  an upgrade where no {@code home_count} pref exists yet): the first
      *  {@link #COLS} apps, or all of them when fewer than {@link #COLS} are
-     *  installed. Mirrors the legacy "first 8 of the stored order" behaviour
-     *  so an upgrade never resets the user to alphabetical. */
+     *  installed. Mirrors the legacy "first {@link #COLS} of the stored order"
+     *  behaviour so an upgrade never resets the user to alphabetical. */
     static int defaultHomeCount(int size) {
         return Math.min(COLS, Math.max(0, size));
     }
@@ -248,7 +248,7 @@ final class HomeDrawerModel {
      *       slot the moved app just vacated. {@code homeCount} stays at
      *       {@link #COLS}.</li>
      *   <li><b>Any lower row</b>: ordinary vertical swap with the cell one row
-     *       up (8 positions earlier).</li>
+     *       up ({@link #COLS} positions earlier).</li>
      * </ul>
      */
     static <T> MoveResult moveUp(List<T> order, int index, int homeCount) {
@@ -299,7 +299,7 @@ final class HomeDrawerModel {
      *       {@code homeCount--}. (It stays in the drawer — only its home
      *       membership changes.)</li>
      *   <li><b>Any other row</b>: ordinary vertical swap with the cell one row
-     *       down (8 positions later), snapping to the nearest existing cell
+     *       down ({@link #COLS} positions later), snapping to the nearest existing cell
      *       when the row below is shorter. No-op on the last row.</li>
      * </ul>
      */

--- a/LauncherV15/app/src/main/java/com/bare/launcher/HomeDrawerModel.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/HomeDrawerModel.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Pure-Java geometry / navigation / reorder logic for the Apple-TV style
+ * Pure-Java geometry / navigation / reorder logic for the TV-style
  * "home favourites row + pull-down app drawer" layout (v1.5.0).
  *
  * <p>The launcher keeps a single flat, ordered list of the apps that are
@@ -44,7 +44,7 @@ final class HomeDrawerModel {
 
     /** Apps per drawer row, and the hard cap on the home-row size. v1.5.0
      *  uses 6 (down from 8) for larger, TV-friendly rounded-square tiles in
-     *  the Apple-TV / Fire-TV idiom. */
+     *  the modern TV idiom. */
     static final int COLS = 6;
 
     /** Sentinel returned by {@link #navUp(int, int, int)} when UP is pressed

--- a/LauncherV15/app/src/main/java/com/bare/launcher/IconDiskCache.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/IconDiskCache.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  *       {@code ResolveInfo.loadIcon} / {@code PackageManager.getActivityIcon}
  *       (~5-15 ms per icon on cheap TV ROMs).</li>
  *   <li>{@link IconRenderer#process}: AdaptiveIconDrawable layering,
- *       white-plate detection via {@link Bitmap#copyPixelsToBuffer},
+ *       white-plate detection via a 12-point {@link Bitmap#getPixel} sample,
  *       circle clip + saveLayer ({@code SRC_IN}) compositing.
  *       (~5-20 ms per icon depending on icon shape.)</li>
  * </ol>

--- a/LauncherV15/app/src/main/java/com/bare/launcher/IconRenderer.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/IconRenderer.java
@@ -95,7 +95,7 @@ final class IconRenderer {
 
     /** Corner-radius fraction for the TV-friendly rounded-square icon mask.
      *  ~0.22 of the side length approximates the continuous-corner
-     *  "squircle" look of Apple TV / Fire TV app tiles without the cost of a
+     *  "squircle" look of modern TV app tiles without the cost of a
      *  real superellipse path. Exposed so {@link RingView} and the cell
      *  placeholders can match the exact same corner so the focus ring hugs
      *  the icon edge. */
@@ -138,12 +138,12 @@ final class IconRenderer {
         sTilePaint.setStyle(Paint.Style.FILL);
     }
 
-    // ── Banner tiles (v1.5.0 — Apple-TV style 5:3 rounded-rect tiles) ─────
+    // ── Banner tiles (v1.5.0 — TV-style 5:3 rounded-rect tiles) ─────
 
     /** Render a real app banner ({@code android:banner}) to a {@code w × h}
      *  rounded-rectangle tile, scaled to COVER (center-crop) so the art fills
      *  the tile with no letterboxing. {@code corner} is the corner radius in
-     *  px (kept small/subtle to match Apple-TV app tiles). */
+     *  px (kept small/subtle to match the tile look). */
     static Bitmap processBannerArt(Drawable d, int w, int h, int corner) {
         if (d == null || w <= 0 || h <= 0) return null;
         int iw = d.getIntrinsicWidth(), ih = d.getIntrinsicHeight();

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -73,7 +73,7 @@ public class LauncherActivity extends Activity {
 
     private static final int    ICON_DP        = 80;   // round chip/list icon cache size
     private static final int    RING_STROKE_DP = 3;
-    // v1.5.0 Apple-TV style 5:3 banner tiles, sized dynamically from the
+    // v1.5.0 TV-style 5:3 banner tiles, sized dynamically from the
     // screen width so exactly 6 fit per row on ANY TV (see computeTileDims()).
     // Volatile: written on the UI thread (onCreate / config change), read on
     // the icon executor inside loadBannerBlocking.
@@ -332,7 +332,7 @@ public class LauncherActivity extends Activity {
     // executors remain here; their hot paths live inside this activity.
     private volatile ExecutorService          appExecutor;
     private volatile LruCache<String, Bitmap> iconCache;
-    /** In-memory cache of Apple-TV style banner tiles for the home / drawer
+    /** In-memory cache of TV-style banner tiles for the home / drawer
      *  cells. Separate from {@link #iconCache} (which holds the small round
      *  chip icons): tiles are a different shape, size, and source. No disk
      *  cache — tiles regenerate per process (cheap: only the visible cells
@@ -352,7 +352,7 @@ public class LauncherActivity extends Activity {
     // drawer cells. See {@link IconTarget}.
     private final ArrayMap<String, List<IconTarget>> iconInflight = new ArrayMap<>();
     /** In-flight banner-tile loads keyed by package. The home / drawer cells
-     *  display Apple-TV style banner tiles (see {@link #bannerCache}); this is
+     *  display TV-style banner tiles (see {@link #bannerCache}); this is
      *  the banner counterpart of {@link #iconInflight}. Delivers to the same
      *  {@link IconTarget} cells (their display bitmap is the banner). */
     private final ArrayMap<String, List<IconTarget>> bannerInflight = new ArrayMap<>();
@@ -1846,7 +1846,7 @@ public class LauncherActivity extends Activity {
         //
         // Color philosophy is unchanged: dark glass idle plate, frosted
         // near-white focused plate, hairline white rim, glyph inverts on
-        // focus. See AppleStyle.makeBgIdlePaint / makeBgFocusPaint /
+        // focus. See ToolbarStyle.makeBgIdlePaint / makeBgFocusPaint /
         // makeRimPaint — every paint factory remains untouched, so the
         // visual vocabulary is identical, just smaller.
         final int BTN_SZ      = dp(28);
@@ -1940,7 +1940,7 @@ public class LauncherActivity extends Activity {
         root.addView(drawer);
 
         int strokePx = dp(RING_STROKE_DP);
-        // Selection ring wraps the Apple-TV banner tile (landscape rounded
+        // Selection ring wraps the banner tile (landscape rounded
         // rect). Box = banner + headroom for the focus scale-up.
         int bw = tileWpx, bh = bannerHpx;
         int ringBoxW = bw + dp(12), ringBoxH = bh + dp(12);
@@ -2004,7 +2004,7 @@ public class LauncherActivity extends Activity {
         android.widget.LinearLayout menuCol = new android.widget.LinearLayout(this);
         menuCol.setOrientation(android.widget.LinearLayout.VERTICAL);
         menuCol.setGravity(Gravity.CENTER_HORIZONTAL);
-        // Apple-TV plate matches the keymap card exactly: deep slate with a
+        // Dark glass plate matches the keymap card exactly: deep slate with a
         // hairline rim. Dropping the previous opaque-black plate gives the
         // app context menu the same visual vocabulary as the rest of the UI.
         android.graphics.drawable.GradientDrawable menuBg =
@@ -2109,7 +2109,7 @@ public class LauncherActivity extends Activity {
 
         // Dividers removed — the rounded-pill selection state is enough to
         // separate items visually, and removing them gives a cleaner
-        // Apple-TV-style menu with no horizontal noise.
+        // menu with no horizontal noise.
         android.widget.LinearLayout.LayoutParams itemLp =
                 new android.widget.LinearLayout.LayoutParams(dp(140), WRAP);
         itemLp.bottomMargin = dp(2);
@@ -2363,7 +2363,7 @@ public class LauncherActivity extends Activity {
                 }
             }
         };
-        applyApplePillStyle(v);
+        applyPillStyle(v);
         v.setOnClickListener(view -> openNetSettings());
         // Short-press → WiFi / network settings. (The long-press → Bluetooth
         // shortcut was removed in v1.5.x: it was unreliable across TV ROMs —
@@ -2450,21 +2450,21 @@ public class LauncherActivity extends Activity {
                 if (focused) {
                     c.drawCircle(cx, cy, r, bgFocus);
                     c.drawCircle(cx, cy, r - rim.getStrokeWidth() / 2f, rim);
-                    AppleStyle.drawGearGlyph(c, cx, cy, r,
-                            AppleStyle.SYMBOL_FOCUSED, bgFocus.getColor(), fill);
+                    ToolbarStyle.drawGearGlyph(c, cx, cy, r,
+                            ToolbarStyle.SYMBOL_FOCUSED, bgFocus.getColor(), fill);
                 } else {
                     // Idle: a soft dark shadow first so the white cog stays
                     // visible on light / white wallpapers, then the white cog
                     // with a real punched-through centre (CLEAR).
                     float sh = Math.max(1f, density) * 1.5f;
-                    AppleStyle.drawGearGlyph(c, cx, cy + sh, r,
+                    ToolbarStyle.drawGearGlyph(c, cx, cy + sh, r,
                             0x59000000, 0x59000000, fill);
-                    AppleStyle.drawGearGlyph(c, cx, cy, r,
-                            AppleStyle.SYMBOL_IDLE, 0x00000000, fill);
+                    ToolbarStyle.drawGearGlyph(c, cx, cy, r,
+                            ToolbarStyle.SYMBOL_IDLE, 0x00000000, fill);
                 }
             }
         };
-        applyApplePillStyle(v);
+        applyPillStyle(v);
         v.setOnClickListener(view -> {
             view.playSoundEffect(SoundEffectConstants.CLICK);
             showSettingsPanel();
@@ -2523,37 +2523,37 @@ public class LauncherActivity extends Activity {
         return v;
     }
 
-    /** Common Apple-TV pill setup is now centralised in {@link AppleStyle}.
-     *  This wrapper exists only so unchanged button-construction call sites
-     *  (which call {@code applyApplePillStyle(v)} unqualified) keep
-     *  compiling. The body is a one-liner forwarding to the shared helper. */
-    private void applyApplePillStyle(View v) {
-        AppleStyle.applyApplePillStyle(v);
+    /** Common toolbar-pill setup is centralised in {@link ToolbarStyle}.
+     *  This wrapper exists only so the button-construction call sites
+     *  (which call {@code applyPillStyle(v)} unqualified) stay tidy. The
+     *  body is a one-liner forwarding to the shared helper. */
+    private void applyPillStyle(View v) {
+        ToolbarStyle.applyPillStyle(v);
     }
 
     private Paint makeBtnPaint(boolean fill) {
-        return AppleStyle.makeBtnPaint(fill);
+        return ToolbarStyle.makeBtnPaint(fill);
     }
 
     private Paint makeBtnStrokePaint() {
-        return AppleStyle.makeBtnStrokePaint();
+        return ToolbarStyle.makeBtnStrokePaint();
     }
 
     /** Idle button background — dark glass that reads on any wallpaper. */
     private Paint makeBgIdlePaint() {
-        return AppleStyle.makeBgIdlePaint();
+        return ToolbarStyle.makeBgIdlePaint();
     }
 
     /** Focused button background — frosted near-white that lifts the symbol
-     *  via inversion. This is the Apple-TV "selected pill" effect. */
+     *  via inversion. This is the "selected pill" effect. */
     private Paint makeBgFocusPaint() {
-        return AppleStyle.makeBgFocusPaint();
+        return ToolbarStyle.makeBgFocusPaint();
     }
 
     /** Hairline inner rim that defines the glass plate edge in any state.
      *  Stroke width is 1 dp scaled by the activity's cached density. */
     private Paint makeRimPaint() {
-        return AppleStyle.makeRimPaint(density);
+        return ToolbarStyle.makeRimPaint(density);
     }
 
     private void openNetSettings() {
@@ -3647,7 +3647,7 @@ public class LauncherActivity extends Activity {
                             View nb = netBtn; if (nb != null) nb.requestFocus(); return true;
                         case KeyEvent.KEYCODE_DPAD_DOWN:
                             // v1.5.0: DOWN on a home cell pulls down the app
-                            // drawer (Apple-TV style). The drawer mirrors the
+                            // drawer (TV style). The drawer mirrors the
                             // current order and lands focus on the same app.
                             // If there are no apps to show, openDrawer no-ops
                             // and we still consume so focus stays put (avoids
@@ -3981,7 +3981,7 @@ public class LauncherActivity extends Activity {
         }
 
         /** Content-space Y of row 0. When the whole grid fits on screen (few
-         *  apps) the block is centred vertically for an Apple-TV look;
+         *  apps) the block is centred vertically for a balanced look;
          *  otherwise it starts at {@code topPad} and scrolls. */
         private int firstRowTop() {
             int rows = HomeDrawerModel.rowCount(displayed.size(), hc());
@@ -6560,7 +6560,7 @@ public class LauncherActivity extends Activity {
      *  and avoids the inflate cost on every reopen.
      *
      *  Visual style: compact dropdown anchored just below the mapper button
-     *  (top-right toolbar). Apple-TV-inspired palette: deep slate plate with
+     *  (top-right toolbar). Dark frosted palette: deep slate plate with
      *  a hairline rim, idle rows transparent + light-grey text, focused row
      *  becomes a bright frosted-white pill with dark text — exactly the same
      *  language as the toolbar buttons (idle dark / focused white-frosted),
@@ -6602,7 +6602,7 @@ public class LauncherActivity extends Activity {
         ov.setFocusableInTouchMode(true);
         ov.setVisibility(View.GONE);
 
-        // Apple-TV style card: deep slate plate, soft 14 dp corners, 1 px
+        // Frosted card: deep slate plate, soft 14 dp corners, 1 px
         // hairline rim, subtle elevation. Slot list and picker swap
         // visibility inside the same card — no second card needed.
         android.widget.LinearLayout card = new android.widget.LinearLayout(this);
@@ -7096,7 +7096,7 @@ public class LauncherActivity extends Activity {
                 }
             }
 
-            // Apple-TV inversion: selected row becomes a bright plate with
+            // Inverted highlight: selected row becomes a bright plate with
             // dark text; idle rows are transparent with light text. The
             // same colour ramp as the toolbar buttons (idle 0xCCFFFFFF,
             // focused 0xFF111114).
@@ -7487,7 +7487,7 @@ public class LauncherActivity extends Activity {
 
     private void paintPickerChip(View chip, boolean sel, boolean animate) {
         if (chip == null) return;
-        // Apple-TV inverted pill: selected chip is bright frosted-white with
+        // Inverted pill: selected chip is bright frosted-white with
         // dark text; idle chips are transparent with light text. Same
         // language as the slot rows and the toolbar buttons.
         android.graphics.drawable.Drawable bgd = chip.getBackground();
@@ -8151,7 +8151,7 @@ public class LauncherActivity extends Activity {
 
     // ── Banner-tile pipeline (v1.5.0) ────────────────────────────────────
     // Mirrors the icon pipeline (preWarmIcon / loadIconAsync) but produces
-    // the Apple-TV style banner tiles the home / drawer cells display, into
+    // the TV-style banner tiles the home / drawer cells display, into
     // {@link #bannerCache} / {@link #bannerInflight}. Delivers to the same
     // {@link IconTarget} cells (their display bitmap is the banner). Does NOT
     // fire {@link #onIconLoaded} — that hook is for the round chip icons.
@@ -8706,10 +8706,10 @@ public class LauncherActivity extends Activity {
 
     private int dp(int v) { return Math.round(v * density); }
 
-    /** Compute the Apple-TV banner-tile pixel dimensions from the current
+    /** Compute the banner-tile pixel dimensions from the current
      *  screen width so exactly 6 tiles fit per row on any TV. Called at
      *  startup (before {@link #buildLayout}) and on configuration change.
-     *  The tile is 5:3 (like tvOS 400x240); the corner is ~20% of the height
+     *  The tile is 5:3 (landscape 400x240-ish); the corner is ~20% of the height
      *  (slightly more rounded per user request), capped so tiles don't get
      *  huge on very wide panels. */
     private void computeTileDims() {

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -100,9 +100,10 @@ public class LauncherActivity extends Activity {
     private static final String KEY_APP_ORDER  = "app_order";
     /** v1.5.0: number of leading apps (in the visible / non-hidden order)
      *  that form the bottom "home favourites" row and, equivalently, the
-     *  centred first row of the pull-down app drawer. Range [0, 8]. Absent on
+     *  centred first row of the pull-down app drawer. Range [0, COLS]. Absent on
      *  first run after the v1.5.0 upgrade → resolved lazily to
-     *  {@link HomeDrawerModel#defaultHomeCount(int)} (the first 8 of the
+     *  {@link HomeDrawerModel#defaultHomeCount(int)} (the first
+     *  {@link HomeDrawerModel#COLS} of the
      *  user's EXISTING stored order) so an upgrade never resets favourites.
      *  The flat {@link #KEY_APP_ORDER} string is unchanged and stays the
      *  single source of truth for ordering; this key only records where the
@@ -920,7 +921,8 @@ public class LauncherActivity extends Activity {
      *
      *  <p>First call with a non-empty list reads the persisted value or, when
      *  absent (the v1.5.0 upgrade), falls back to
-     *  {@link HomeDrawerModel#defaultHomeCount(int)} — the first 8 of the
+     *  {@link HomeDrawerModel#defaultHomeCount(int)} — the first
+     *  {@link HomeDrawerModel#COLS} of the
      *  user's EXISTING stored order — and writes it back so the migration
      *  default sticks. Later calls only re-clamp in memory (persisting a
      *  shrink, e.g. when the user hides enough apps that the home row no
@@ -3474,7 +3476,7 @@ public class LauncherActivity extends Activity {
                             if (f && isAttachedToWindow() && getWidth() > 0)
                                 positionRing(CellView.this);
                         } else if (f) {
-                            // Subtle bouncy focus-IN: OvershootInterpolator(2.0)
+                            // Subtle bouncy focus-IN: OvershootInterpolator(2.8)
                             // ticks the cell ~7-8 % past FOCUS_SCALE then settles.
                             // Reads as a tiny "tap" of life on selection without
                             // dominating the shelf or stressing slow GPUs.

--- a/LauncherV15/app/src/main/java/com/bare/launcher/ToolbarStyle.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/ToolbarStyle.java
@@ -15,7 +15,7 @@ import android.view.View;
 import android.view.ViewOutlineProvider;
 
 /**
- * Static helpers for the launcher's "Apple-TV pill" toolbar buttons.
+ * Static helpers for the launcher's glass-pill toolbar buttons.
  *
  * <p>Every glyph button in the top toolbar (network, mapper, wallpaper)
  * shares the same circular plate visual language:
@@ -34,7 +34,7 @@ import android.view.ViewOutlineProvider;
  * the visual contract explicit and lets future buttons opt into the same
  * vocabulary by calling these factories instead of re-deriving them.
  *
- * <p>{@link #applyApplePillStyle(View)} is the focus-side counterpart:
+ * <p>{@link #applyPillStyle(View)} is the focus-side counterpart:
  * round outline clipping, no platform focus rectangle, hardware layer,
  * sound effects on. Every toolbar button calls it once at construction.
  *
@@ -43,9 +43,9 @@ import android.view.ViewOutlineProvider;
  * {@code LauncherActivity}; pulling them out drops ~70 lines from the
  * activity and makes the visual contract reusable.
  */
-final class AppleStyle {
+final class ToolbarStyle {
 
-    private AppleStyle() { /* no instances */ }
+    private ToolbarStyle() { /* no instances */ }
 
     /** Shared CLEAR-mode xfermode used by {@link #drawGearGlyph} to punch
      *  the cog's centre hole when it floats plate-less over the wallpaper.
@@ -63,7 +63,7 @@ final class AppleStyle {
      * <p>Idempotent: calling twice on the same view leaves it in the same
      * state as one call. Safe to call after the view is attached.
      */
-    static void applyApplePillStyle(View v) {
+    static void applyPillStyle(View v) {
         v.setLayerType(View.LAYER_TYPE_HARDWARE, null);
         v.setBackground(null);
         v.setForeground(null);
@@ -119,7 +119,7 @@ final class AppleStyle {
     }
 
     /** Focused plate paint — frosted near-white that lifts the symbol
-     *  via inversion. The Apple-TV "selected pill" look. */
+     *  via inversion. The "selected pill" look. */
     static Paint makeBgFocusPaint() {
         Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
         p.setStyle(Paint.Style.FILL);


### PR DESCRIPTION
First public release of the redesigned launcher banner-tile home favourites row + pull-down app drawer, unified Move flow, About screen with browser-openable QR links, 3-state clock, and floating Wi-Fi/gear icons. Rolls up every unreleased increment since v1.4.7 (1.4.8, 1.4.9, the 1.5.x drawer/banner overhaul) plus the About-link / Wi-Fi-cleanup / post-update banner-refresh pass and the comment cleanup. SemVer MAJOR bump; upgrade is transparent (favourites seed from the existing order).