### PR TITLE
fix(keymap): button-shortcut picker binds the selected app, not the o…

### DIFF
--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -563,9 +563,20 @@ public class LauncherActivity extends Activity {
     private TextView                    keymapPickerTitle   = null;  // "Pick app for Red"
     private android.widget.HorizontalScrollView keymapPickerHsv = null;
     private android.widget.LinearLayout keymapPickerStrip   = null;  // horizontal app chips
-    private int                         keymapPickerIdx     = 0;     // 0 = "None" sentinel, 1..N = appList[i-1]
+    private int                         keymapPickerIdx     = 0;     // 0 = "None" sentinel, 1..N = keymapPickerApps[i-1]
     private int                         keymapPickerLastIdx = -1;    // tracks last-painted selection so refresh only animates the two chips that changed
     private int                         keymapPickerSlotRow = 0;     // which slot row triggered the picker
+    /** Stable, ALPHABETICALLY-SORTED snapshot of the apps shown in the
+     *  picker chip strip. Built together with the chips in
+     *  {@link #rebuildPickerChips}; every picker consumer (commit,
+     *  pre-select, icon top-up, live icon delivery) resolves through THIS
+     *  list, never through {@link #appList} by position. That is the fix
+     *  for the "I pick app A but app B gets bound" bug: the home/drawer
+     *  order can be reordered freely without ever changing which chip maps
+     *  to which package, because the picker order is alphabetical and
+     *  independent of the shelf/drawer order. Chip {@code i} (after the
+     *  leading "Not assigned" sentinel) maps to {@code keymapPickerApps.get(i)}. */
+    private final java.util.List<AppInfo> keymapPickerApps = new ArrayList<>();
     // Picker chip strip is rebuilt only when the underlying app list
     // changes — avoids re-allocating ~N TextViews on every overlay open.
     private int                         keymapPickerBuiltSize = -1;
@@ -7224,12 +7235,13 @@ public class LauncherActivity extends Activity {
         }
         // Pre-select the chip matching the current binding so left/right
         // navigates from where the user is, not always from the start.
+        // Resolve against the picker's own sorted snapshot — never appList.
         int kc = SHORTCUT_KEYCODES[rowIdx];
         String pkg = keyMap.get(kc);
         int idx = 0; // 0 = "None" sentinel
         if (pkg != null) {
-            for (int i = 0; i < appList.size(); i++) {
-                if (appList.get(i).packageName.equals(pkg)) { idx = i + 1; break; }
+            for (int i = 0; i < keymapPickerApps.size(); i++) {
+                if (keymapPickerApps.get(i).packageName.equals(pkg)) { idx = i + 1; break; }
             }
         }
         keymapPickerIdx     = idx;
@@ -7260,8 +7272,11 @@ public class LauncherActivity extends Activity {
             keyMap.delete(kc);
         } else {
             int appIdx = keymapPickerIdx - 1;
-            if (appIdx >= 0 && appIdx < appList.size()) {
-                keyMap.put(kc, appList.get(appIdx).packageName);
+            // Resolve through the picker's sorted snapshot — the chip the
+            // user highlighted ALWAYS maps to this exact app, regardless of
+            // any later home/drawer reorder.
+            if (appIdx >= 0 && appIdx < keymapPickerApps.size()) {
+                keyMap.put(kc, keymapPickerApps.get(appIdx).packageName);
             }
         }
         saveKeyMap();
@@ -7272,19 +7287,28 @@ public class LauncherActivity extends Activity {
         exitAppPicker();
     }
 
-    /** Rebuild the chip strip from the current appList. Called only when
-     *  the app list size has changed since the last build (see enterAppPicker),
-     *  not on every reopen. Each chip is a small horizontal LinearLayout
-     *  with an optional icon and a label. */
+    /** Rebuild the chip strip from a stable, alphabetically-sorted snapshot
+     *  of {@link #appList}. Called when the app-list size changes since the
+     *  last build (see enterAppPicker) or when a package broadcast / reconcile
+     *  invalidates the cache — NOT on every reopen. The picker order is
+     *  intentionally INDEPENDENT of the home/drawer order: reordering apps on
+     *  the shelf or in the drawer never changes which chip maps to which
+     *  package, so a binding can't drift onto the wrong app. */
     private void rebuildPickerChips() {
         android.widget.LinearLayout strip = keymapPickerStrip;
         if (strip == null) return;
         strip.removeAllViews();
+        // Stable alphabetical snapshot — the single source of truth for the
+        // chip order AND for every package lookup the picker performs.
+        keymapPickerApps.clear();
+        keymapPickerApps.addAll(appList);
+        Collections.sort(keymapPickerApps,
+                (a, b) -> String.CASE_INSENSITIVE_ORDER.compare(a.label, b.label));
         // First chip is the "Not assigned" sentinel — always present so the
         // user can clear a binding from the picker without a separate gesture.
         addPickerChip(strip, getString(R.string.keymap_not_assigned), null, true);
-        for (int i = 0; i < appList.size(); i++) {
-            AppInfo a = appList.get(i);
+        for (int i = 0; i < keymapPickerApps.size(); i++) {
+            AppInfo a = keymapPickerApps.get(i);
             Bitmap b = (iconCache != null) ? iconCache.get(a.packageName) : null;
             addPickerChip(strip, a.label, b, false);
         }
@@ -7292,11 +7316,11 @@ public class LauncherActivity extends Activity {
 
     /** Mirror of {@link #refreshHideChipIcons} for the keymap picker strip.
      *  The picker has a leading "Not assigned" sentinel chip with no
-     *  ImageView, so chip i in the strip corresponds to appList[i-1]. */
+     *  ImageView, so chip i in the strip corresponds to keymapPickerApps[i-1]. */
     private void refreshPickerChipIcons() {
         android.widget.LinearLayout strip = keymapPickerStrip;
         if (strip == null || iconCache == null) return;
-        int n = Math.min(strip.getChildCount() - 1, appList.size());
+        int n = Math.min(strip.getChildCount() - 1, keymapPickerApps.size());
         for (int i = 0; i < n; i++) {
             View chip = strip.getChildAt(i + 1); // +1 skips the sentinel
             if (!(chip instanceof android.widget.LinearLayout)) continue;
@@ -7306,7 +7330,7 @@ public class LauncherActivity extends Activity {
             if (!(v instanceof ImageView)) continue;
             ImageView iv = (ImageView) v;
             if (iv.getVisibility() == View.VISIBLE && iv.getDrawable() != null) continue;
-            Bitmap b = iconCache.get(appList.get(i).packageName);
+            Bitmap b = iconCache.get(keymapPickerApps.get(i).packageName);
             if (b != null) {
                 iv.setImageBitmap(b);
                 iv.setVisibility(View.VISIBLE);
@@ -7330,7 +7354,6 @@ public class LauncherActivity extends Activity {
         // this right now?" signal.
         FrameLayout ko = keymapOverlay;
         if (ko == null || ko.getVisibility() != View.VISIBLE) return;
-        int idx = indexInAppList(pkg);
         // Hide-manager strip: rows are indexed by hideListApps (the filtered
         // subset of hidden apps), NOT by appList. Indexing the strip with the
         // appList index painted the icon onto the wrong hidden row (icon/name
@@ -7347,11 +7370,18 @@ public class LauncherActivity extends Activity {
                 }
             }
         }
-        // Picker strip: leading sentinel offsets app indices by 1.
+        // Picker strip: match by package against the picker's sorted snapshot
+        // (the leading "Not assigned" sentinel offsets chip indices by 1).
         if (keymapMode == KEYMAP_MODE_PICKER) {
             android.widget.LinearLayout pStrip = keymapPickerStrip;
-            if (pStrip != null && idx >= 0 && (idx + 1) < pStrip.getChildCount()) {
-                setChipIcon(pStrip.getChildAt(idx + 1), 0, bmp);
+            if (pStrip != null) {
+                for (int i = 0, n = keymapPickerApps.size(); i < n; i++) {
+                    if (pkg.equals(keymapPickerApps.get(i).packageName)) {
+                        if ((i + 1) < pStrip.getChildCount())
+                            setChipIcon(pStrip.getChildAt(i + 1), 0, bmp);
+                        break;
+                    }
+                }
             }
         }
         // Slot rows: only when the slot list is the active sub-mode AND
@@ -7372,17 +7402,6 @@ public class LauncherActivity extends Activity {
             }
             if (bound) refreshKeymapRows();
         }
-    }
-
-    /** Linear scan over appList for the given pkg. Cheap (≤ ~50 entries on
-     *  a typical TV) and only used by {@link #onIconLoaded} which itself
-     *  is rate-limited by icon-decode throughput. Avoids a parallel
-     *  pkg→index map purely for this one path. */
-    private int indexInAppList(String pkg) {
-        for (int i = 0, n = appList.size(); i < n; i++) {
-            if (pkg.equals(appList.get(i).packageName)) return i;
-        }
-        return -1;
     }
 
     /** Set the bitmap on an ImageView at a fixed child index inside a chip
@@ -7728,11 +7747,19 @@ public class LauncherActivity extends Activity {
         if (strip == null) return;
         strip.removeAllViews();
         hideListApps.clear();
-        // Only hidden apps appear here; row i ↔ hideListApps.get(i).
+        // Only hidden apps appear here, in stable ALPHABETICAL order — row
+        // i ↔ hideListApps.get(i). The order is independent of the
+        // home/drawer order so it never shifts under a reorder, and every
+        // consumer (toggle, icon top-up, live icon delivery) resolves
+        // through this same list by package.
         for (int i = 0; i < appList.size(); i++) {
             AppInfo a = appList.get(i);
-            if (!hiddenApps.contains(a.packageName)) continue;
-            hideListApps.add(a);
+            if (hiddenApps.contains(a.packageName)) hideListApps.add(a);
+        }
+        Collections.sort(hideListApps,
+                (a, b) -> String.CASE_INSENSITIVE_ORDER.compare(a.label, b.label));
+        for (int i = 0; i < hideListApps.size(); i++) {
+            AppInfo a = hideListApps.get(i);
             Bitmap b = (iconCache != null) ? iconCache.get(a.packageName) : null;
             addHideRow(strip, a.label, b);
         }

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -152,6 +152,13 @@ public class LauncherActivity extends Activity {
     // under the 200 ms threshold where animations start to feel sluggish.
     private static final int    FOCUS_DUR_MS   = 150;
     private static final int    UNFOCUS_DUR_MS = 100;
+    // Pull-down drawer open/close transition duration. Open and close share
+    // this single value so the two feel symmetric — the close used to be
+    // shorter (140 ms) and restored the home screen instantly, which read as
+    // an abrupt "snap" on return. On close the home content now cross-fades
+    // in over this same window (see closeDrawer / beginHomeFadeIn) so the
+    // drawer sliding down and the home appearing blend into one motion.
+    private static final int    DRAWER_ANIM_MS = 200;
 
     // Easing curves. Defined once, reused everywhere — no per-animation alloc.
     //   FOCUS_EASE      — decelerate-out, the canonical "press / lift" curve
@@ -1039,12 +1046,18 @@ public class LauncherActivity extends Activity {
         if (d.getVisibility() == View.VISIBLE) return;
         List<AppInfo> visible = buildVisibleList();
         if (visible.isEmpty()) return;
+        resetHomeAlpha();   // clear any leftover alpha from an interrupted close-fade
         resolveHomeCount(visible.size());
         int hc = effectiveHomeCount(visible.size());
         d.setApps(visible, hc);
-        // The drawer's first hc cells ARE the home apps, so a home-row index
-        // maps 1:1 to a drawer index. Clamp defensively.
-        int focus = Math.min(Math.max(0, s.focusedIndex), visible.size() - 1);
+        // The drawer's row 0 IS the home favourites row, so the focused home
+        // cell maps 1:1 to a drawer index. Pressing DOWN drops the selector
+        // into the drawer ONE ROW BELOW the favourite the user was on — the
+        // app sitting directly under it (navDown). When the home row is the
+        // only row (few apps), navDown returns the same index so focus simply
+        // stays on the favourite. Clamp the home index defensively.
+        int homeIdx = Math.min(Math.max(0, s.focusedIndex), Math.max(0, hc - 1));
+        int focus = HomeDrawerModel.navDown(homeIdx, visible.size(), hc);
         d.open(focus);
         // Hide the home shelf while the drawer covers the screen so we never
         // draw both grids at once (the drawer's row 0 already mirrors the home
@@ -1106,7 +1119,47 @@ public class LauncherActivity extends Activity {
         int homeIdx = (drawerFocus >= 0 && drawerFocus < hc) ? drawerFocus : Math.max(0, hc - 1);
         s2.focusedIndex = homeIdx;
         s2.snapNextFocus = true;   // calm, no focus-bounce on return
+        // Cross-fade the home surface in as the drawer slides down — mirrors
+        // the open animation so the return reads as one smooth motion instead
+        // of an instant pop. Set alpha to 0 BEFORE pushHomeRow binds + paints
+        // the cells, then animate to opaque over the same window as the
+        // drawer's downward fade.
+        beginHomeFadeIn();
         pushHomeRow(s2, visibleSnapshot, hc);
+    }
+
+    /** Fade the home surface (shelf, clock, selection ring) from transparent
+     *  to opaque over {@link #DRAWER_ANIM_MS}, concurrently with the drawer's
+     *  downward fade in {@link #closeDrawer}. The small corner toolbar pills
+     *  are left to their own idle alpha (they reappear at the screen edge
+     *  where an instant restore isn't perceptible); fading the central
+     *  content is what removes the "snap". Cheap — a handful of alpha tweens,
+     *  the shelf flattened to one GPU layer for the duration via withLayer. */
+    private void beginHomeFadeIn() {
+        fadeViewIn(shelf, true);
+        if (showClock) fadeViewIn(clockView, false);
+        fadeViewIn(ringView, false);
+    }
+
+    private void fadeViewIn(View v, boolean withLayer) {
+        if (v == null) return;
+        v.animate().cancel();
+        v.setAlpha(0f);
+        android.view.ViewPropertyAnimator a = v.animate()
+                .alpha(1f).setDuration(DRAWER_ANIM_MS).setInterpolator(SCROLL_EASE);
+        if (withLayer) a.withLayer();
+        a.start();
+    }
+
+    /** Snap the home surface (shelf, clock, ring) back to full opacity and
+     *  cancel any in-flight fade. Guards against an interrupted close-fade —
+     *  the drawer reopened, or an app launched, mid-fade — leaving any of
+     *  them stuck semi-transparent. Cheap; called on drawer-open and on the
+     *  resume-time drawer teardown. */
+    private void resetHomeAlpha() {
+        RecyclingShelfView s = shelf; if (s != null) { s.animate().cancel(); s.setAlpha(1f); }
+        TextView cv = clockView;      if (cv != null) { cv.animate().cancel(); cv.setAlpha(1f); }
+        RingView rv = ringView;       if (rv != null) { rv.animate().cancel(); rv.setAlpha(1f); }
     }
 
     /** Frosted-glass backdrop for the drawer: GPU-blur the (static) wallpaper
@@ -1353,6 +1406,7 @@ public class LauncherActivity extends Activity {
             if (d2 != null) d2.forceHide();
             RecyclingShelfView sh = shelf;
             if (sh != null) {
+                resetHomeAlpha();   // app may have launched mid close-fade — clear leftover alpha
                 sh.setVisibility(View.VISIBLE);
                 List<AppInfo> vis = buildVisibleList();
                 pushHomeRow(sh, vis, effectiveHomeCount(vis.size()));
@@ -3461,7 +3515,7 @@ public class LauncherActivity extends Activity {
 
                 setOnClickListener(v -> {
                     if (boundApp == null) return;
-                    if (!reorderMode) launchApp(boundApp);
+                    if (!reorderMode) launchApp(boundApp, v);
                     // In reorder mode clicks are consumed but do nothing — menu buttons handle confirm/cancel
                 });
 
@@ -4308,7 +4362,7 @@ public class LauncherActivity extends Activity {
             setTranslationY(h * 0.06f);
             animate().cancel();
             animate().alpha(1f).translationY(0f)
-                    .setDuration(180).setInterpolator(SCROLL_EASE)
+                    .setDuration(DRAWER_ANIM_MS).setInterpolator(SCROLL_EASE)
                     // Hardware layer for the duration of the fade: the drawer
                     // is a ViewGroup full of banner+label cells, so animating
                     // its alpha would otherwise re-blend every child every
@@ -4337,7 +4391,7 @@ public class LauncherActivity extends Activity {
             RingView rv0 = ringView; if (rv0 != null) rv0.setVisibility(View.INVISIBLE);
             int h = getHeight() > 0 ? getHeight() : screenH;
             animate().alpha(0f).translationY(h * 0.06f)
-                    .setDuration(140).setInterpolator(SCROLL_EASE)
+                    .setDuration(DRAWER_ANIM_MS).setInterpolator(SCROLL_EASE)
                     // Clear the open() ring-glue update listener. ViewPropertyAnimator
                     // retains mUpdateListener across cancel()+start(), so without this
                     // the open-time positionRing listener keeps firing during the close
@@ -4558,7 +4612,7 @@ public class LauncherActivity extends Activity {
 
                 setOnClickListener(v -> {
                     if (boundApp == null) return;
-                    if (!reorderMode) launchApp(boundApp);
+                    if (!reorderMode) launchApp(boundApp, v);
                 });
                 setOnLongClickListener(v -> {
                     if (boundApp == null || reorderMode) return true;
@@ -5243,7 +5297,17 @@ public class LauncherActivity extends Activity {
         }
     }
 
-    private void launchApp(AppInfo app) {
+    private void launchApp(AppInfo app) { launchApp(app, null); }
+
+    /** Launch {@code app}, optionally animating the new activity scaling up
+     *  from {@code source} (the tile the user activated) for a clean
+     *  "open from the icon" effect. A {@code null} {@code source} (e.g. a
+     *  remote-key shortcut, which has no on-screen tile) uses the system
+     *  default transition. The scale-up is a window-animation hint — free at
+     *  our end and silently ignored by ROMs that don't honour custom launch
+     *  animations, so there is no performance cost or compatibility risk. */
+    private void launchApp(AppInfo app, View source) {
+        final android.os.Bundle anim = launchAnimBundle(source);
         // Direct-intent fast path. PackageManager.getLaunchIntentForPackage
         // does TWO synchronous binder calls internally
         // (queryIntentActivities for CATEGORY_INFO, fall back to
@@ -5265,7 +5329,7 @@ public class LauncherActivity extends Activity {
                     .setPackage(app.packageName)
                     .setComponent(app.component)
                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(fast);
+            startActivity(fast, anim);
             return;
         } catch (Exception ignored) {
             // Fall through to the legacy paths — they have caught every
@@ -5282,7 +5346,7 @@ public class LauncherActivity extends Activity {
             Intent i = pm.getLaunchIntentForPackage(app.packageName);
             if (i != null) {
                 i.setComponent(app.component); i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(i);
+                startActivity(i, anim);
                 return;
             }
         } catch (Exception ignored) {}
@@ -5293,8 +5357,25 @@ public class LauncherActivity extends Activity {
         try {
             Intent d = new Intent(Intent.ACTION_MAIN);
             d.setComponent(app.component); d.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(d);
+            startActivity(d, anim);
         } catch (Exception e) { showToast(getString(R.string.toast_app_unavailable)); }
+    }
+
+    /** Build a scale-up launch-animation options bundle anchored on
+     *  {@code source}, or {@code null} when there is no usable source view
+     *  (the caller then passes {@code null} to {@code startActivity} and gets
+     *  the system default). {@code startActivity(Intent, Bundle)} accepts a
+     *  null bundle identically to the single-arg overload. */
+    private android.os.Bundle launchAnimBundle(View source) {
+        if (source == null || !source.isAttachedToWindow()
+                || source.getWidth() <= 0 || source.getHeight() <= 0) return null;
+        try {
+            return android.app.ActivityOptions
+                    .makeScaleUpAnimation(source, 0, 0, source.getWidth(), source.getHeight())
+                    .toBundle();
+        } catch (Exception ignored) {
+            return null;
+        }
     }
 
     // ── Remote-key → app shortcut routing ────────────────────────────────


### PR DESCRIPTION
…ne at that grid position

The picker chip strip and its commit both keyed off appList by position, but the home/drawer reorder changes appList order without always rebuilding the strip. Result: after moving an app in the drawer, picking a chip bound the app now sitting at that index instead of the one shown (and a late icon could land on the wrong chip).

Fix: the picker now builds a stable, ALPHABETICALLY-sorted snapshot (keymapPickerApps) and every consumer - chip build, pre-select, commit, icon top-up, and live icon delivery - resolves through that snapshot by package. Because alphabetical order is independent of the shelf/drawer order, reordering apps can never change which chip maps to which package. The hidden-apps manager list is likewise sorted alphabetically (it already rebuilt per open and resolved by package, so it had no stale-binding bug - this is consistency only). Slot rows already resolved bindings by package via findAppByPackage, so they were correct.