### PR TITLE
feat(tv-inputs): surface HDMI/AV inputs as app-like tiles (2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to BareLauncher land here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] — 2026-06-25
+
+### What's new
+
+- **TV inputs as tiles.** Your TV's HDMI, AV and other inputs now show up
+  as their own tiles (HDMI 1, HDMI 2, …) right alongside your apps. Open
+  one to switch straight to that input, and move, place, or hide it
+  anywhere just like an app. (Only appears on TVs that actually have these
+  inputs.)
+
 ## [2.0.0] — 2026-06-25
 
 A brand-new look. BareLauncher gets a fresh home screen and a pull-down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   one to switch straight to that input, and move, place, or hide it
   anywhere just like an app. (Only appears on TVs that actually have these
   inputs.)
+- A cleaner return from the app drawer to the home screen — the selected
+  app tile no longer looks slightly cut off at the top.
 
 ## [2.0.0] — 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
   inputs.)
 - A cleaner return from the app drawer to the home screen — the selected
   app tile no longer looks slightly cut off at the top.
+- Uninstalling an app from the drawer now keeps you in the drawer, so you
+  can tidy up several apps in a row without it closing each time.
+- Unhiding an app now puts it back in the app drawer instead of bumping
+  one of your home-screen favourites out of place.
+- A fresh, rounded look for the support and latest-version QR codes, each
+  with its logo in the middle.
 
 ## [2.0.0] — 2026-06-25
 

--- a/LauncherV15/app/build.gradle.kts
+++ b/LauncherV15/app/build.gradle.kts
@@ -421,8 +421,15 @@ android {
         // Move flow), plus the About browser-link / Wi-Fi-cleanup / post-
         // update banner-refresh pass. See CHANGELOG.md [2.0.0] for the
         // user-facing summary.
-        versionCode   = 28
-        versionName   = "2.0.0"
+        //
+        // Bumped 28 → 29: 2.1.0 adds hardware TV inputs (HDMI / AV /
+        // component) as first-class app-like tiles via the platform TV Input
+        // Framework — they sort, place, move, hide, and bind exactly like
+        // apps, launch by switching to the passthrough source, and need NO
+        // special permission. A pure no-op on devices without TV inputs
+        // (streaming sticks, most boxes). SemVer MINOR — additive feature.
+        versionCode   = 29
+        versionName   = "2.1.0"
         resourceConfigurations += listOf("en")
 
         // Instrumentation test runner. Required so :app:connectedDebugAndroidTest

--- a/LauncherV15/app/src/main/AndroidManifest.xml
+++ b/LauncherV15/app/src/main/AndroidManifest.xml
@@ -37,6 +37,14 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
+    <!-- TV Input Framework: lets the launcher surface hardware inputs
+         (HDMI / AV / component) as tiles and switch to them. Declared NOT
+         required so the APK still installs on devices without TV inputs;
+         enumeration/launch need no runtime permission (see TvInputs). -->
+    <uses-feature
+        android:name="android.software.live_tv"
+        android:required="false" />
+
     <!-- PACKAGE VISIBILITY (Android 11+) -->
     <queries>
 

--- a/LauncherV15/app/src/main/java/com/bare/launcher/AppInfo.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/AppInfo.java
@@ -91,10 +91,38 @@ final class AppInfo {
      */
     String displayLabel;
 
+    /**
+     * Non-null only for a TV-input "app" (HDMI 1, AV, tuner, …) surfaced from
+     * the platform TV Input Framework. When set, this entry is launched by
+     * switching to the passthrough input via {@code TvContract} rather than by
+     * starting an activity, its banner tile is a generated input glyph, and
+     * the "Uninstall" / "App info" context-menu rows are suppressed (an input
+     * is not an installed package). Everything else — ordering, home/drawer
+     * placement, reorder, hide, remote-key binding — treats it exactly like a
+     * normal app. {@code null} for ordinary apps. See {@link TvInputs}.
+     */
+    final String tvInputId;
+
     AppInfo(String pkg, String lbl, ComponentName cmp, ResolveInfo r) {
+        this(pkg, lbl, cmp, r, null);
+    }
+
+    private AppInfo(String pkg, String lbl, ComponentName cmp, ResolveInfo r, String tvInput) {
         packageName = pkg;
         label       = lbl;
         component   = cmp;
         ri          = r;
+        tvInputId   = tvInput;
+    }
+
+    /** Build a TV-input entry. The synthetic {@link #packageName}
+     *  ({@code "tvinput://" + inputId}) is the stable key used everywhere a
+     *  package name is — order persistence, the hidden set, the icon/banner
+     *  caches, remote-key bindings — so an input round-trips through all of
+     *  them like any other app. It can never collide with a real package
+     *  (real package names are never of this shape) and contains no comma, so
+     *  it is safe inside the comma-separated persisted order string. */
+    static AppInfo tvInput(String inputId, String label) {
+        return new AppInfo("tvinput://" + inputId, label, null, null, inputId);
     }
 }

--- a/LauncherV15/app/src/main/java/com/bare/launcher/AppListCache.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/AppListCache.java
@@ -296,6 +296,12 @@ final class AppListCache {
      *  serialisation path the JVM tests exercise. */
     static Entry from(final AppInfo a) {
         if (a == null) return null;
+        // TV-input entries are not persisted to the cold-start cache — they
+        // carry no serialisable package/activity and are re-enumerated fresh
+        // from the TV Input Framework on every {@code loadApps} scan. Skipping
+        // them here keeps the cache to real apps; the live order (KEY_APP_ORDER)
+        // still records their position so they reappear where the user put them.
+        if (a.tvInputId != null) return null;
         final String cls = a.component != null ? a.component.getClassName() : null;
         return new Entry() {
             @Override public String pkg()           { return a.packageName; }

--- a/LauncherV15/app/src/main/java/com/bare/launcher/IconRenderer.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/IconRenderer.java
@@ -8,6 +8,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.RectF;
+import android.graphics.Typeface;
 import android.graphics.drawable.AdaptiveIconDrawable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
@@ -181,6 +182,60 @@ final class IconRenderer {
             int ix = (w - isz) / 2, iy = (h - isz) / 2;
             icon.setBounds(ix, iy, ix + isz, iy + isz);
             icon.draw(c);
+        }
+        return out;
+    }
+
+    /** Generate a {@code w × h} rounded-rectangle tile for a hardware TV
+     *  input (HDMI / AV / …): a dark slate plate with a centred display glyph
+     *  and the input's label drawn beneath it, so each input tile is
+     *  self-identifying at rest (there is no per-input artwork). {@code corner}
+     *  px corner radius; {@code density} scales the stroke floors.
+     *
+     *  <p>Uses locally-allocated {@link Paint}s (not the shared static ones)
+     *  because it mutates colour / text-size and may run concurrently with
+     *  app-tile generation on the icon-executor pool. Input tiles are few and
+     *  generated once each (then cached), so the per-call allocation is
+     *  negligible — correctness over the micro-optimisation here. */
+    static Bitmap generateInputTile(int w, int h, int corner, String label, float density) {
+        if (w <= 0 || h <= 0) return null;
+        Bitmap out = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(out);
+        Paint bg = new Paint(Paint.ANTI_ALIAS_FLAG);
+        bg.setStyle(Paint.Style.FILL);
+        bg.setColor(0xFF1E2A38);                             // slate-blue: distinct from app tiles
+        c.drawRoundRect(new RectF(0, 0, w, h), corner, corner, bg);
+
+        // Display/monitor glyph (screen + stand), centred in the upper area.
+        Paint glyph = new Paint(Paint.ANTI_ALIAS_FLAG);
+        glyph.setStyle(Paint.Style.STROKE);
+        glyph.setStrokeWidth(Math.max(density, h * 0.035f));
+        glyph.setStrokeJoin(Paint.Join.ROUND);
+        glyph.setStrokeCap(Paint.Cap.ROUND);
+        glyph.setColor(0xFFE6F0FF);
+        float cx = w / 2f;
+        float screenW = w * 0.30f, screenH = h * 0.26f;
+        float top = h * 0.20f;
+        RectF screen = new RectF(cx - screenW / 2f, top, cx + screenW / 2f, top + screenH);
+        float sc = Math.min(screenW, screenH) * 0.18f;
+        c.drawRoundRect(screen, sc, sc, glyph);
+        float standY = top + screenH + h * 0.06f;
+        c.drawLine(cx, top + screenH, cx, standY, glyph);            // neck
+        c.drawLine(cx - screenW * 0.24f, standY, cx + screenW * 0.24f, standY, glyph); // base
+
+        // Label beneath the glyph, shrunk to fit the tile width.
+        if (label != null && !label.isEmpty()) {
+            Paint tp = new Paint(Paint.ANTI_ALIAS_FLAG);
+            tp.setColor(0xFFFFFFFF);
+            tp.setTextAlign(Paint.Align.CENTER);
+            tp.setFakeBoldText(true);
+            tp.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+            tp.setTextSize(h * 0.17f);
+            float maxW = w * 0.86f;
+            while (tp.measureText(label) > maxW && tp.getTextSize() > 8f) {
+                tp.setTextSize(tp.getTextSize() - 1f);
+            }
+            c.drawText(label, cx, h * 0.86f, tp);
         }
         return out;
     }

--- a/LauncherV15/app/src/main/java/com/bare/launcher/IconRenderer.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/IconRenderer.java
@@ -240,6 +240,44 @@ final class IconRenderer {
         return out;
     }
 
+    /** Small {@code sz × sz} input glyph for the compact chip strips (the
+     *  button-shortcut picker and the hide manager), where a TV input has no
+     *  app icon to show. Draws the same slate plate + display-monitor glyph as
+     *  {@link #generateInputTile} but square and label-free (the chip already
+     *  shows the input's name as its own text). The chip's ImageView clips it
+     *  to a circle, so the result reads as a little round "input" badge that
+     *  matches the round app icons beside it. {@code density} floors the
+     *  stroke width so the glyph stays crisp on low-density panels.
+     *
+     *  <p>Locally-allocated paints (like {@link #generateInputTile}); called
+     *  only when a chip strip is (re)built — never on a hot path. */
+    static Bitmap generateInputGlyphIcon(int sz, float density) {
+        if (sz <= 0) return null;
+        Bitmap out = Bitmap.createBitmap(sz, sz, Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(out);
+        Paint bg = new Paint(Paint.ANTI_ALIAS_FLAG);
+        bg.setStyle(Paint.Style.FILL);
+        bg.setColor(0xFF1E2A38);                 // same slate-blue as the input tile
+        c.drawRect(0, 0, sz, sz, bg);            // full square; the chip clips to a circle
+
+        Paint glyph = new Paint(Paint.ANTI_ALIAS_FLAG);
+        glyph.setStyle(Paint.Style.STROKE);
+        glyph.setStrokeWidth(Math.max(density, sz * 0.06f));
+        glyph.setStrokeJoin(Paint.Join.ROUND);
+        glyph.setStrokeCap(Paint.Cap.ROUND);
+        glyph.setColor(0xFFE6F0FF);
+        float cx = sz / 2f, cy = sz / 2f;
+        float scrW = sz * 0.46f, scrH = sz * 0.34f;
+        float top  = cy - scrH * 0.62f;
+        RectF screen = new RectF(cx - scrW / 2f, top, cx + scrW / 2f, top + scrH);
+        float r = Math.min(scrW, scrH) * 0.18f;
+        c.drawRoundRect(screen, r, r, glyph);
+        float standY = top + scrH + sz * 0.12f;
+        c.drawLine(cx, top + scrH, cx, standY, glyph);                       // neck
+        c.drawLine(cx - scrW * 0.26f, standY, cx + scrW * 0.26f, standY, glyph); // base
+        return out;
+    }
+
     /**
      * Convert any launcher {@link Drawable} into a TV-friendly rounded-square
      * {@code sz × sz} {@link Bitmap.Config#ARGB_8888} bitmap, ready for the

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -432,6 +432,17 @@ public class LauncherActivity extends Activity {
      *  acted-on app occupied so focus lands sensibly on return. */
     private boolean keepDrawerOpenOnResume = false;
     private int     pendingDrawerFocusIdx  = 0;
+    /** Drawer index to re-focus after the post-uninstall reconcile rebuilds the
+     *  drawer list (so the selector stays on the uninstalled app's slot — the
+     *  app that slid into it — instead of being clamped to the last cell). -1
+     *  when idle. Mirrors the in-place refocus the Hide path does directly. */
+    private int     pendingDrawerRefocus   = -1;
+    /** Package being uninstalled from the drawer, and whether it was a home-row
+     *  app, so the reconcile can shrink the home row by one ONLY when the
+     *  uninstall actually went through (a cancelled dialog leaves the package
+     *  installed → no change). {@code null} when idle. */
+    private String  pendingUninstallPkg     = null;
+    private boolean pendingUninstallWasHome = false;
     private ViewTreeObserver.OnGlobalLayoutListener focusRestoreListener;
     private final int[]    ringCellLoc      = new int[2];
     private final int[]    ringRootLoc      = new int[2];
@@ -1087,6 +1098,10 @@ public class LauncherActivity extends Activity {
      *  back to the toolbar so focus is never lost. */
     private void closeDrawer() {
         AppDrawer d = drawer;
+        // Leaving the drawer cancels any pending post-uninstall refocus / home
+        // shrink so they can't apply to a later, unrelated reconcile.
+        pendingDrawerRefocus = -1;
+        pendingUninstallPkg  = null;
         if (d == null || d.getVisibility() != View.VISIBLE) return;
         if (d.closing) return;   // a close is already animating — ignore re-triggers (held DPAD-UP)
         final int drawerFocus = d.focusedIndex;
@@ -1268,8 +1283,18 @@ public class LauncherActivity extends Activity {
      *                    sensible neighbouring cell to refocus. */
     private void hideApp(AppInfo app, boolean fromDrawer, int focusHint) {
         if (app == null) return;
+        // Was the hidden app sitting in the home row? Capture BEFORE mutating
+        // the hidden set (focusHint is the app's index on its surface: a shelf
+        // index is always a home slot; a drawer index is a home slot when it's
+        // below the home boundary).
+        int oldHc = effectiveHomeCount(countVisible(appList));
+        boolean wasHome = focusHint >= 0 && focusHint < oldHc;
         if (!hiddenApps.add(app.packageName)) return;   // already hidden — no-op
         saveHiddenApps();
+        // Shrink the home row by one when a home favourite is hidden, so its
+        // slot simply disappears instead of the first drawer app being pulled
+        // up to keep the row at its old size. (Drawer apps don't affect it.)
+        if (wasHome && homeCount > 1) { homeCount--; saveHomeCount(); }
         // The Manage-hidden-apps list is rebuilt lazily; this app must now
         // appear there. (buildHideChips rebuilds from hiddenApps on open.)
         keymapHideBuiltSize = -1;
@@ -1463,6 +1488,8 @@ public class LauncherActivity extends Activity {
                 });
             } else {
                 keepDrawerOpenOnResume = false;
+                pendingDrawerRefocus = -1;
+                pendingUninstallPkg  = null;
                 if (d2 != null) d2.forceHide();
                 RecyclingShelfView sh = shelf;
                 if (sh != null) {
@@ -4656,6 +4683,7 @@ public class LauncherActivity extends Activity {
         void triggerUninstall() {
             AppInfo app = (dragIndex >= 0 && dragIndex < displayed.size()) ? displayed.get(dragIndex) : null;
             int idx = dragIndex;
+            boolean wasHome = idx >= 0 && idx < hc();
             exitReorderMode(false);   // dismiss the context menu, but keep the drawer open
             if (app == null) return;
             // Stay in the drawer on return (mirrors Hide). The uninstall dialog
@@ -4664,7 +4692,16 @@ public class LauncherActivity extends Activity {
             // flag if the system dialog actually launches (else we'd never
             // pause/resume to clear it).
             LauncherActivity.this.pendingDrawerFocusIdx = Math.max(0, idx);
-            LauncherActivity.this.keepDrawerOpenOnResume = LauncherActivity.this.doUninstall(app);
+            boolean launched = LauncherActivity.this.doUninstall(app);
+            LauncherActivity.this.keepDrawerOpenOnResume = launched;
+            if (launched) {
+                // Keep the selector on this slot after the reconcile, and shrink
+                // the home row if a home app was removed — but only once the
+                // reconcile confirms the package is actually gone (cancel-safe).
+                LauncherActivity.this.pendingDrawerRefocus    = Math.max(0, idx);
+                LauncherActivity.this.pendingUninstallPkg      = app.packageName;
+                LauncherActivity.this.pendingUninstallWasHome  = wasHome;
+            }
         }
         void triggerHide() {
             int idx = dragIndex;
@@ -5090,6 +5127,18 @@ public class LauncherActivity extends Activity {
                                 AppInfo a = freshFinal.get(i);
                                 appByPackage.put(a.packageName, a);
                             }
+                            // Cancel-safe home-row shrink: if an app uninstalled
+                            // from the drawer was a home favourite AND is now
+                            // actually gone, drop the home count by one so the
+                            // home row loses that slot instead of pulling the
+                            // first drawer app up. Done BEFORE applyShelfApps so
+                            // the rebuild uses the new count.
+                            if (pendingUninstallPkg != null && !freshPkgs.contains(pendingUninstallPkg)) {
+                                if (pendingUninstallWasHome && homeCount > 1) {
+                                    homeCount--; saveHomeCount();
+                                }
+                                pendingUninstallPkg = null;
+                            }
                             RecyclingShelfView s = shelf;
                             if (s != null) {
                                 // A6 fix: the saved scroll index is a
@@ -5113,6 +5162,25 @@ public class LauncherActivity extends Activity {
                                     pendingScrollIdx = -1;
                                 }
                                 applyShelfApps(s);
+                            }
+                            // Task: after an uninstall from the open drawer, put
+                            // the selector back on the slot the removed app left
+                            // (the app that slid into it), not the last cell.
+                            // Posted after applyShelfApps' setApps focus post, so
+                            // this one wins. Mirrors the Hide path's in-place
+                            // refocus.
+                            if (pendingDrawerRefocus >= 0) {
+                                final int h = pendingDrawerRefocus;
+                                pendingDrawerRefocus = -1;
+                                final AppDrawer dd = drawer;
+                                if (dd != null && dd.getVisibility() == View.VISIBLE) {
+                                    dd.post(() -> {
+                                        if (dd.getVisibility() != View.VISIBLE) return;
+                                        int n = countVisible(appList);
+                                        if (n > 0) dd.requestFocusOnIndex(
+                                                Math.max(0, Math.min(h, n - 1)), true);
+                                    });
+                                }
                             }
                             // A2 fix: when a package broadcast fires
                             // while the user is INSIDE the keymap card's
@@ -6711,10 +6779,12 @@ public class LauncherActivity extends Activity {
                     : R.string.about_qr_github_caption);
         }
         if (aboutQrLink != null) {
-            // Ko-fi shows the raw URL (the user asked for the full link text);
-            // GitHub shows the short "BareLauncher latest version" label.
+            // Ko-fi shows the link without the "https://" scheme (cleaner, and
+            // a browser fills the scheme in anyway); GitHub shows the short
+            // "BareLauncher latest version" label. aboutQrUrl keeps the full
+            // URL for the actual open.
             aboutQrLink.setText(which == ABOUT_ROW_KOFI
-                    ? url
+                    ? url.replaceFirst("^https?://", "")
                     : getString(R.string.about_github_link_button));
         }
         aboutShowingQr = true;

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -1133,10 +1133,21 @@ public class LauncherActivity extends Activity {
      *  downward fade in {@link #closeDrawer}. The small corner toolbar pills
      *  are left to their own idle alpha (they reappear at the screen edge
      *  where an instant restore isn't perceptible); fading the central
-     *  content is what removes the "snap". Cheap — a handful of alpha tweens,
-     *  the shelf flattened to one GPU layer for the duration via withLayer. */
+     *  content is what removes the "snap". Cheap — a handful of alpha tweens.
+     *
+     *  The shelf fades WITHOUT a hardware layer. A withLayer() fade flattens
+     *  the shelf to a GPU texture sized to the shelf's bounds — but the shelf
+     *  is only one cell tall (its height == cellHpx) and the focused tile is
+     *  scaled to FOCUS_SCALE, so its banner overflows the shelf's top edge by
+     *  ~3 %. The layer clipped that overflow, leaving a thin slice shaved off
+     *  the top of the selected icon for the whole return fade. The shelf has
+     *  clipChildren=false, so fading without a layer lets the scaled tile draw
+     *  past the shelf bounds (into the root) un-clipped. The home row is a
+     *  single row of non-overlapping tiles, so a per-child alpha fade is
+     *  visually identical to a layered one — and marginally cheaper (no layer
+     *  alloc / save-restore). */
     private void beginHomeFadeIn() {
-        fadeViewIn(shelf, true);
+        fadeViewIn(shelf, false);
         if (showClock) fadeViewIn(clockView, false);
         fadeViewIn(ringView, false);
         // Toolbar pills fade in to their dim idle alpha (0.6 — the rest value

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -3057,6 +3057,24 @@ public class LauncherActivity extends Activity {
                     resolveSize(cellH, hSpec));
         }
 
+        /** The home row is a single line of spaced tiles that never overlap
+         *  one another, so the group does not need offscreen compositing to
+         *  apply alpha correctly. Returning {@code false} is what actually
+         *  fixes the return-from-drawer clip: a ViewGroup with overlapping
+         *  rendering (the default) renders into an offscreen buffer the moment
+         *  its alpha drops below 1 — and that buffer is sized to the shelf's
+         *  bounds. Since the shelf is exactly one cell tall and the focused
+         *  tile is scaled to FOCUS_SCALE, the tile's banner overflows the top
+         *  edge and the buffer shaves a thin black sliver off it for the whole
+         *  close cross-fade (the HOME button doesn't hit this because its
+         *  teardown restores alpha to 1 instantly, never an intermediate
+         *  value). With overlapping rendering off, the alpha is distributed to
+         *  each cell and composited straight into the (clipChildren=false)
+         *  root, so the scaled tile draws un-clipped. Non-overlapping children
+         *  mean the per-child alpha is visually identical to the buffered
+         *  path. */
+        @Override public boolean hasOverlappingRendering() { return false; }
+
         void setApps(List<AppInfo> apps) {
             if (reorderMode) exitReorderMode(false); // guard: don't corrupt dragIndex on list refresh
             hideContextMenu();

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -487,6 +487,10 @@ public class LauncherActivity extends Activity {
      *  entry to reorder mode by whichever of the home shelf / app drawer is
      *  reordering. See {@link ReorderHost}. */
     private ReorderHost        menuHost      = null;
+    /** True while the context menu is acting on a TV-input tile, so the
+     *  Uninstall / App-info rows are hidden and {@link #menuNavSel} skips
+     *  them. Set in {@link #showContextMenu(View)}. */
+    private boolean            menuRowsInputMode = false;
     private       TextView    menuHide      = null;
     private       TextView    menuUninstall = null;
     private       TextView    menuAppInfo   = null;
@@ -1194,7 +1198,7 @@ public class LauncherActivity extends Activity {
      *  manages its reorder teardown). Mirrors the shelf's ACTION_DELETE →
      *  ACTION_UNINSTALL_PACKAGE fallback chain. */
     private void doUninstall(AppInfo app) {
-        if (app == null) return;
+        if (app == null || app.tvInputId != null) return;   // inputs aren't uninstallable
         Uri pkgUri = Uri.fromParts("package", app.packageName, null);
         Intent primary = new Intent(Intent.ACTION_DELETE, pkgUri)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -1209,7 +1213,7 @@ public class LauncherActivity extends Activity {
     /** Open the system "App info" page for {@code app}. Shared by the drawer
      *  cell's reorder menu. */
     private void doAppInfo(AppInfo app) {
-        if (app == null) return;
+        if (app == null || app.tvInputId != null) return;   // inputs have no App-info page
         Intent i = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
                 Uri.fromParts("package", app.packageName, null))
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -2195,6 +2199,15 @@ public class LauncherActivity extends Activity {
 
     void showContextMenu(View cell) {
         if (menuOverlay == null || menuHide == null || menuUninstall == null || menuAppInfo == null || menuMove == null) return;
+        // TV-input tiles can't be uninstalled or have an App-info page — hide
+        // those two rows so the menu shows only Hide + Move. Set BEFORE the
+        // measure below so the overlay sizes to the shorter list. menuNavSel
+        // then skips the hidden rows during D-pad navigation.
+        ReorderHost host = menuHost;
+        menuRowsInputMode = (host != null && host.menuAppIsInput());
+        int extraVis = menuRowsInputMode ? View.GONE : View.VISIBLE;
+        menuUninstall.setVisibility(extraVis);
+        menuAppInfo.setVisibility(extraVis);
         cell.getLocationOnScreen(menuCellLoc);
         FrameLayout r = root; if (r == null) return;
         r.getLocationOnScreen(menuRootLoc);
@@ -2307,6 +2320,30 @@ public class LauncherActivity extends Activity {
                     fm.setScaleY(1f);
                 })
                 .start();
+    }
+
+    /** Context-menu rows in top→bottom visual order. {@link #menuNavSel} walks
+     *  these so UP/DOWN navigation and the input-mode row-skipping live in one
+     *  place instead of being duplicated (and drifting) across the two cell
+     *  key handlers. */
+    private static final int[] MENU_ROWS_FULL = {
+            RecyclingShelfView.MENU_HIDE, RecyclingShelfView.MENU_UNINSTALL,
+            RecyclingShelfView.MENU_APP_INFO, RecyclingShelfView.MENU_MOVE };
+    /** Input tiles expose only Hide + Move (no Uninstall / App-info). */
+    private static final int[] MENU_ROWS_INPUT = {
+            RecyclingShelfView.MENU_HIDE, RecyclingShelfView.MENU_MOVE };
+
+    /** Next menu selection when navigating from {@code cur} by {@code dir}
+     *  ({@code -1} = UP toward Hide, {@code +1} = DOWN toward Move), clamped
+     *  at the ends and skipping the rows hidden in {@link #menuRowsInputMode}.
+     *  For a normal app this reproduces the previous hard-coded chain exactly
+     *  (Hide ↔ Uninstall ↔ App info ↔ Move). */
+    private int menuNavSel(int cur, int dir) {
+        int[] order = menuRowsInputMode ? MENU_ROWS_INPUT : MENU_ROWS_FULL;
+        int idx = 0;
+        for (int i = 0; i < order.length; i++) if (order[i] == cur) { idx = i; break; }
+        idx = Math.max(0, Math.min(order.length - 1, idx + dir));
+        return order[idx];
     }
 
     void updateMenuHighlight() {
@@ -2788,6 +2825,10 @@ public class LauncherActivity extends Activity {
 
         // ── ReorderHost (shared context menu) ────────────────────────────
         @Override public int menuSelection() { return menuSelection; }
+        @Override public boolean menuAppIsInput() {
+            return dragIndex >= 0 && dragIndex < displayed.size()
+                    && displayed.get(dragIndex).tvInputId != null;
+        }
         @Override public void onMenuHide() {
             if (!reorderMode) return;
             menuSelection = MENU_HIDE;
@@ -3637,15 +3678,9 @@ public class LauncherActivity extends Activity {
                             case KeyEvent.KEYCODE_DPAD_RIGHT:
                                 return true;   // no move until "Move" is confirmed
                             case KeyEvent.KEYCODE_DPAD_UP:
-                                if      (menuSelection == MENU_MOVE)     { menuSelection = MENU_APP_INFO;  updateMenuHighlight(); }
-                                else if (menuSelection == MENU_APP_INFO) { menuSelection = MENU_UNINSTALL; updateMenuHighlight(); }
-                                else if (menuSelection == MENU_UNINSTALL){ menuSelection = MENU_HIDE;      updateMenuHighlight(); }
-                                return true;
+                                menuSelection = menuNavSel(menuSelection, -1); updateMenuHighlight(); return true;
                             case KeyEvent.KEYCODE_DPAD_DOWN:
-                                if      (menuSelection == MENU_HIDE)      { menuSelection = MENU_UNINSTALL; updateMenuHighlight(); }
-                                else if (menuSelection == MENU_UNINSTALL) { menuSelection = MENU_APP_INFO;  updateMenuHighlight(); }
-                                else if (menuSelection == MENU_APP_INFO)  { menuSelection = MENU_MOVE;      updateMenuHighlight(); }
-                                return true;
+                                menuSelection = menuNavSel(menuSelection, +1); updateMenuHighlight(); return true;
                             case KeyEvent.KEYCODE_DPAD_CENTER: case KeyEvent.KEYCODE_ENTER:
                             case KeyEvent.KEYCODE_BUTTON_A:
                                 if      (menuSelection == MENU_UNINSTALL) triggerUninstall();
@@ -3726,6 +3761,7 @@ public class LauncherActivity extends Activity {
 
             void triggerUninstall() {
                 if (boundApp == null) return;
+                if (boundApp.tvInputId != null) { exitReorderMode(false); return; }   // not for inputs
                 final AppInfo appToUninstall = boundApp;
                 final Uri pkgUri = Uri.fromParts("package", appToUninstall.packageName, null);
 
@@ -3762,6 +3798,7 @@ public class LauncherActivity extends Activity {
              *  path is well-supported but cheap-TV ROMs occasionally strip it. */
             void triggerAppInfo() {
                 if (boundApp == null) return;
+                if (boundApp.tvInputId != null) { exitReorderMode(false); return; }   // not for inputs
                 final String pkg = boundApp.packageName;
                 exitReorderMode(false);
                 Intent i = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
@@ -3977,6 +4014,10 @@ public class LauncherActivity extends Activity {
 
         // ── ReorderHost (shared context menu) ────────────────────────────
         @Override public int menuSelection() { return menuSelection; }
+        @Override public boolean menuAppIsInput() {
+            return dragIndex >= 0 && dragIndex < displayed.size()
+                    && displayed.get(dragIndex).tvInputId != null;
+        }
         @Override public void onMenuHide() {
             if (!reorderMode) return;
             menuSelection = RecyclingShelfView.MENU_HIDE;
@@ -4679,15 +4720,9 @@ public class LauncherActivity extends Activity {
                         // Stage 1 — menu shown: UP/DOWN navigate, OK selects.
                         switch (kc) {
                             case KeyEvent.KEYCODE_DPAD_UP:
-                                if      (menuSelection == RecyclingShelfView.MENU_MOVE)     { menuSelection = RecyclingShelfView.MENU_APP_INFO;  updateMenuHighlight(); }
-                                else if (menuSelection == RecyclingShelfView.MENU_APP_INFO) { menuSelection = RecyclingShelfView.MENU_UNINSTALL; updateMenuHighlight(); }
-                                else if (menuSelection == RecyclingShelfView.MENU_UNINSTALL){ menuSelection = RecyclingShelfView.MENU_HIDE;     updateMenuHighlight(); }
-                                return true;
+                                menuSelection = menuNavSel(menuSelection, -1); updateMenuHighlight(); return true;
                             case KeyEvent.KEYCODE_DPAD_DOWN:
-                                if      (menuSelection == RecyclingShelfView.MENU_HIDE)      { menuSelection = RecyclingShelfView.MENU_UNINSTALL; updateMenuHighlight(); }
-                                else if (menuSelection == RecyclingShelfView.MENU_UNINSTALL) { menuSelection = RecyclingShelfView.MENU_APP_INFO; updateMenuHighlight(); }
-                                else if (menuSelection == RecyclingShelfView.MENU_APP_INFO)  { menuSelection = RecyclingShelfView.MENU_MOVE;     updateMenuHighlight(); }
-                                return true;
+                                menuSelection = menuNavSel(menuSelection, +1); updateMenuHighlight(); return true;
                             case KeyEvent.KEYCODE_DPAD_LEFT:
                             case KeyEvent.KEYCODE_DPAD_RIGHT:
                                 return true; // no move until "Move" is confirmed (stage 2)
@@ -5224,6 +5259,12 @@ public class LauncherActivity extends Activity {
             //noinspection deprecation
             addApps(pm.queryIntentActivities(second, 0), self, seen, out);
         }
+        // Append hardware TV inputs (HDMI / AV / component …) as app-like
+        // entries so they sort, place, move, hide, and bind exactly like
+        // apps. Empty on devices without TIF inputs — a clean no-op. Done
+        // here (on the app executor) so the one binder query never touches
+        // the UI thread. See {@link TvInputs}.
+        out.addAll(TvInputs.enumerate(this));
         Collections.sort(out, (a, b) -> String.CASE_INSENSITIVE_ORDER.compare(a.label, b.label));
         return out;
     }
@@ -5308,6 +5349,16 @@ public class LauncherActivity extends Activity {
      *  animations, so there is no performance cost or compatibility risk. */
     private void launchApp(AppInfo app, View source) {
         final android.os.Bundle anim = launchAnimBundle(source);
+        // TV-input entry: switch to the passthrough source (HDMI/AV/…) via
+        // the system Live-TV app instead of starting an activity. Scale-up
+        // animation from the tile is reused. Toast if no app can switch
+        // inputs (e.g. a box with TIF inputs but no Live-TV handler).
+        if (app.tvInputId != null) {
+            if (!TvInputs.launch(this, app.tvInputId, anim)) {
+                showToast(getString(R.string.toast_input_unavailable));
+            }
+            return;
+        }
         // Direct-intent fast path. PackageManager.getLaunchIntentForPackage
         // does TWO synchronous binder calls internally
         // (queryIntentActivities for CATEGORY_INFO, fall back to
@@ -8288,6 +8339,11 @@ public class LauncherActivity extends Activity {
     private Bitmap loadBannerBlocking(AppInfo app) {
         if (app == null) return null;
         final int w = tileWpx, h = bannerHpx, corner = tileCornerPx;
+        // TV-input tile: a generated glyph + label (there is no app banner or
+        // icon to resolve). Distinct, self-identifying at rest.
+        if (app.tvInputId != null) {
+            return IconRenderer.generateInputTile(w, h, corner, app.label, density);
+        }
         Drawable banner = resolveBannerDrawable(app);
         if (banner != null) {
             Bitmap b = IconRenderer.processBannerArt(banner, w, h, corner);

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -487,10 +487,6 @@ public class LauncherActivity extends Activity {
      *  entry to reorder mode by whichever of the home shelf / app drawer is
      *  reordering. See {@link ReorderHost}. */
     private ReorderHost        menuHost      = null;
-    /** True while the context menu is acting on a TV-input tile, so the
-     *  Uninstall / App-info rows are hidden and {@link #menuNavSel} skips
-     *  them. Set in {@link #showContextMenu(View)}. */
-    private boolean            menuRowsInputMode = false;
     private       TextView    menuHide      = null;
     private       TextView    menuUninstall = null;
     private       TextView    menuAppInfo   = null;
@@ -2204,8 +2200,8 @@ public class LauncherActivity extends Activity {
         // measure below so the overlay sizes to the shorter list. menuNavSel
         // then skips the hidden rows during D-pad navigation.
         ReorderHost host = menuHost;
-        menuRowsInputMode = (host != null && host.menuAppIsInput());
-        int extraVis = menuRowsInputMode ? View.GONE : View.VISIBLE;
+        boolean inputMode = (host != null && host.menuAppIsInput());
+        int extraVis = inputMode ? View.GONE : View.VISIBLE;
         menuUninstall.setVisibility(extraVis);
         menuAppInfo.setVisibility(extraVis);
         cell.getLocationOnScreen(menuCellLoc);
@@ -2335,11 +2331,15 @@ public class LauncherActivity extends Activity {
 
     /** Next menu selection when navigating from {@code cur} by {@code dir}
      *  ({@code -1} = UP toward Hide, {@code +1} = DOWN toward Move), clamped
-     *  at the ends and skipping the rows hidden in {@link #menuRowsInputMode}.
-     *  For a normal app this reproduces the previous hard-coded chain exactly
-     *  (Hide ↔ Uninstall ↔ App info ↔ Move). */
+     *  at the ends and skipping the Uninstall / App-info rows when the menu is
+     *  acting on a TV input. Input-mode is read LIVE from the active host (not
+     *  a cached flag) so navigation can never run against a stale mode — the
+     *  dragged item is fixed while the menu is open, so this is O(1) and
+     *  stable. For a normal app this reproduces the previous hard-coded chain
+     *  exactly (Hide ↔ Uninstall ↔ App info ↔ Move). */
     private int menuNavSel(int cur, int dir) {
-        int[] order = menuRowsInputMode ? MENU_ROWS_INPUT : MENU_ROWS_FULL;
+        boolean input = (menuHost != null && menuHost.menuAppIsInput());
+        int[] order = input ? MENU_ROWS_INPUT : MENU_ROWS_FULL;
         int idx = 0;
         for (int i = 0; i < order.length; i++) if (order[i] == cur) { idx = i; break; }
         idx = Math.max(0, Math.min(order.length - 1, idx + dir));

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -1139,27 +1139,41 @@ public class LauncherActivity extends Activity {
         fadeViewIn(shelf, true);
         if (showClock) fadeViewIn(clockView, false);
         fadeViewIn(ringView, false);
+        // Toolbar pills fade in to their dim idle alpha (0.6 — the rest value
+        // their own focus listeners use), so an unfocused pill lands correctly
+        // and the corner cluster no longer pops while the centre cross-fades.
+        // No hardware layer: they're tiny leaf views, a plain alpha tween is
+        // already free.
+        fadeViewIn(netBtn, 0.6f, false);
+        fadeViewIn(mapperBtnView, 0.6f, false);
     }
 
     private void fadeViewIn(View v, boolean withLayer) {
+        fadeViewIn(v, 1f, withLayer);
+    }
+
+    private void fadeViewIn(View v, float to, boolean withLayer) {
         if (v == null) return;
         v.animate().cancel();
         v.setAlpha(0f);
         android.view.ViewPropertyAnimator a = v.animate()
-                .alpha(1f).setDuration(DRAWER_ANIM_MS).setInterpolator(SCROLL_EASE);
+                .alpha(to).setDuration(DRAWER_ANIM_MS).setInterpolator(SCROLL_EASE);
         if (withLayer) a.withLayer();
         a.start();
     }
 
-    /** Snap the home surface (shelf, clock, ring) back to full opacity and
-     *  cancel any in-flight fade. Guards against an interrupted close-fade —
-     *  the drawer reopened, or an app launched, mid-fade — leaving any of
-     *  them stuck semi-transparent. Cheap; called on drawer-open and on the
-     *  resume-time drawer teardown. */
+    /** Snap the home surface (shelf, clock, ring, toolbar pills) back to its
+     *  resting opacity and cancel any in-flight fade. Guards against an
+     *  interrupted close-fade — the drawer reopened, or an app launched,
+     *  mid-fade — leaving any of them stuck semi-transparent. Pills reset to
+     *  their dim idle alpha (0.6); the others to fully opaque. Cheap; called
+     *  on drawer-open and on the resume-time drawer teardown. */
     private void resetHomeAlpha() {
         RecyclingShelfView s = shelf; if (s != null) { s.animate().cancel(); s.setAlpha(1f); }
         TextView cv = clockView;      if (cv != null) { cv.animate().cancel(); cv.setAlpha(1f); }
         RingView rv = ringView;       if (rv != null) { rv.animate().cancel(); rv.setAlpha(1f); }
+        View nb = netBtn;             if (nb != null) { nb.animate().cancel(); nb.setAlpha(0.6f); }
+        View mb = mapperBtnView;      if (mb != null) { mb.animate().cancel(); mb.setAlpha(0.6f); }
     }
 
     /** Frosted-glass backdrop for the drawer: GPU-blur the (static) wallpaper

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -3892,14 +3892,26 @@ public class LauncherActivity extends Activity {
                 // uninstall on several TV ROMs, which masked the success.
                 Intent primary = new Intent(Intent.ACTION_DELETE, pkgUri)
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                if (tryUninstall(primary)) return;
+                if (tryUninstall(primary)) { armHomeUninstall(appToUninstall); return; }
 
                 @SuppressWarnings("deprecation")
                 Intent fallback = new Intent(Intent.ACTION_UNINSTALL_PACKAGE, pkgUri)
                         .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                if (tryUninstall(fallback)) return;
+                if (tryUninstall(fallback)) { armHomeUninstall(appToUninstall); return; }
 
                 showToast(getString(R.string.toast_cannot_uninstall, appToUninstall.label));
+            }
+
+            /** Record that a HOME-row app is being uninstalled so the
+             *  package-removed reconcile shrinks the home row by one (the
+             *  shelf only ever shows home apps, so this is always a home
+             *  uninstall). Cancel-safe: the reconcile only acts once the
+             *  package is confirmed gone. No drawer refocus — the drawer is
+             *  closed when uninstalling from the home screen. */
+            private void armHomeUninstall(AppInfo app) {
+                LauncherActivity.this.pendingUninstallPkg     = app.packageName;
+                LauncherActivity.this.pendingUninstallWasHome = true;
+                LauncherActivity.this.pendingDrawerRefocus    = -1;
             }
 
             /** Open the system "App info" page for the focused app.

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -917,15 +917,13 @@ public class LauncherActivity extends Activity {
         // would render in the OLD cached order for ~200 ms before the
         // PM-scan reconcile detects the order change and re-renders —
         // visible as a transient flicker after every reorder + reboot.
-        // Best-effort write on a background thread.
+        // Best-effort write on a background thread: appExecutor uses a
+        // DiscardPolicy, so a saturated (or shut-down) executor silently
+        // drops the task rather than throwing — the cache then converges
+        // on the next loadApps reconcile that detects the new order.
         final ArrayList<AppInfo> snapshot = new ArrayList<>(appList);
         final Context appCtx = getApplicationContext();
-        try {
-            appExecutor.execute(() -> AppListCache.writeFileFromAppInfo(appCtx, snapshot));
-        } catch (java.util.concurrent.RejectedExecutionException ignored) {
-            // Executor saturated; the cache will converge on the next
-            // loadApps reconcile that detects the new order.
-        }
+        appExecutor.execute(() -> AppListCache.writeFileFromAppInfo(appCtx, snapshot));
     }
 
     /** Persist the home/drawer boundary. Cheap and synchronous — written only
@@ -1147,30 +1145,27 @@ public class LauncherActivity extends Activity {
      *  visually identical to a layered one — and marginally cheaper (no layer
      *  alloc / save-restore). */
     private void beginHomeFadeIn() {
-        fadeViewIn(shelf, false);
-        if (showClock) fadeViewIn(clockView, false);
-        fadeViewIn(ringView, false);
+        fadeViewIn(shelf);
+        if (showClock) fadeViewIn(clockView);
+        fadeViewIn(ringView);
         // Toolbar pills fade in to their dim idle alpha (0.6 — the rest value
         // their own focus listeners use), so an unfocused pill lands correctly
         // and the corner cluster no longer pops while the centre cross-fades.
-        // No hardware layer: they're tiny leaf views, a plain alpha tween is
-        // already free.
-        fadeViewIn(netBtn, 0.6f, false);
-        fadeViewIn(mapperBtnView, 0.6f, false);
+        fadeViewIn(netBtn, 0.6f);
+        fadeViewIn(mapperBtnView, 0.6f);
     }
 
-    private void fadeViewIn(View v, boolean withLayer) {
-        fadeViewIn(v, 1f, withLayer);
+    private void fadeViewIn(View v) {
+        fadeViewIn(v, 1f);
     }
 
-    private void fadeViewIn(View v, float to, boolean withLayer) {
+    private void fadeViewIn(View v, float to) {
         if (v == null) return;
         v.animate().cancel();
         v.setAlpha(0f);
-        android.view.ViewPropertyAnimator a = v.animate()
-                .alpha(to).setDuration(DRAWER_ANIM_MS).setInterpolator(SCROLL_EASE);
-        if (withLayer) a.withLayer();
-        a.start();
+        v.animate()
+                .alpha(to).setDuration(DRAWER_ANIM_MS).setInterpolator(SCROLL_EASE)
+                .start();
     }
 
     /** Snap the home surface (shelf, clock, ring, toolbar pills) back to its

--- a/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/LauncherActivity.java
@@ -420,6 +420,18 @@ public class LauncherActivity extends Activity {
      *  drawer (correct context), while a genuine return to the launcher still
      *  lands on a freshly-built home screen. */
     private boolean drawerWasOpenAtPause = false;
+
+    /** Set when Uninstall / App-info is invoked from the OPEN drawer. Both
+     *  launch a system screen (so the activity pauses), but unlike an app
+     *  launch we want to come back INTO the drawer — mirroring Hide, which
+     *  stays in the drawer. When this is true on {@link #onResume} the
+     *  deferred teardown keeps the drawer open and re-asserts its focus /
+     *  backdrop instead of restoring the home screen. The package-removed
+     *  reconcile (loadApps → applyShelfApps → setApps) refreshes the drawer's
+     *  list in place. {@link #pendingDrawerFocusIdx} carries the slot the
+     *  acted-on app occupied so focus lands sensibly on return. */
+    private boolean keepDrawerOpenOnResume = false;
+    private int     pendingDrawerFocusIdx  = 0;
     private ViewTreeObserver.OnGlobalLayoutListener focusRestoreListener;
     private final int[]    ringCellLoc      = new int[2];
     private final int[]    ringRootLoc      = new int[2];
@@ -1213,28 +1225,30 @@ public class LauncherActivity extends Activity {
      *  cell's reorder menu; the shelf cell keeps its own copy (which also
      *  manages its reorder teardown). Mirrors the shelf's ACTION_DELETE →
      *  ACTION_UNINSTALL_PACKAGE fallback chain. */
-    private void doUninstall(AppInfo app) {
-        if (app == null || app.tvInputId != null) return;   // inputs aren't uninstallable
+    private boolean doUninstall(AppInfo app) {
+        if (app == null || app.tvInputId != null) return false;   // inputs aren't uninstallable
         Uri pkgUri = Uri.fromParts("package", app.packageName, null);
         Intent primary = new Intent(Intent.ACTION_DELETE, pkgUri)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if (tryStartActivityResolved(primary)) return;
+        if (tryStartActivityResolved(primary)) return true;
         @SuppressWarnings("deprecation")
         Intent fallback = new Intent(Intent.ACTION_UNINSTALL_PACKAGE, pkgUri)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if (tryStartActivityResolved(fallback)) return;
+        if (tryStartActivityResolved(fallback)) return true;
         showToast(getString(R.string.toast_cannot_uninstall, app.label));
+        return false;
     }
 
     /** Open the system "App info" page for {@code app}. Shared by the drawer
-     *  cell's reorder menu. */
-    private void doAppInfo(AppInfo app) {
-        if (app == null || app.tvInputId != null) return;   // inputs have no App-info page
+     *  cell's reorder menu. Returns whether the system screen was launched. */
+    private boolean doAppInfo(AppInfo app) {
+        if (app == null || app.tvInputId != null) return false;   // inputs have no App-info page
         Intent i = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
                 Uri.fromParts("package", app.packageName, null))
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        if (tryStartActivityResolved(i)) return;
+        if (tryStartActivityResolved(i)) return true;
         showToast(getString(R.string.toast_no_app_info));
+        return false;
     }
 
     /** Hide {@code app} from the home shelf and drawer. The app stays
@@ -1420,20 +1434,53 @@ public class LauncherActivity extends Activity {
         // transition animates from the drawer instead of a flashed home
         // screen. forceHide also clears the wallpaper blur and restores the
         // toolbar/clock chrome.
+        boolean drawerKeptOpen = false;
         if (drawerWasOpenAtPause) {
             drawerWasOpenAtPause = false;
             AppDrawer d2 = drawer;
-            if (d2 != null) d2.forceHide();
-            RecyclingShelfView sh = shelf;
-            if (sh != null) {
-                resetHomeAlpha();   // app may have launched mid close-fade — clear leftover alpha
-                sh.setVisibility(View.VISIBLE);
-                List<AppInfo> vis = buildVisibleList();
-                pushHomeRow(sh, vis, effectiveHomeCount(vis.size()));
+            if (keepDrawerOpenOnResume && d2 != null && d2.getVisibility() == View.VISIBLE) {
+                // Uninstall / App-info was launched from the drawer — keep the
+                // drawer open on return (mirrors Hide). Snap it to its resting
+                // open state (a close/open tween may have been cancelled mid-
+                // flight at pause), re-assert the frosted backdrop, and land
+                // focus back on the slot the acted-on app occupied. The
+                // package-removed reconcile refreshes the list in place.
+                keepDrawerOpenOnResume = false;
+                drawerKeptOpen = true;
+                d2.animate().cancel();
+                d2.setAlpha(1f);
+                d2.setTranslationY(0f);
+                applyDrawerBlur(true);
+                setHomeChromeVisible(false);
+                RecyclingShelfView sh = shelf;
+                if (sh != null) sh.setVisibility(View.INVISIBLE);
+                final AppDrawer fd = d2;
+                final int hint = pendingDrawerFocusIdx;
+                fd.post(() -> {
+                    if (fd.getVisibility() != View.VISIBLE) return;
+                    int n = countVisible(appList);
+                    if (n > 0) fd.requestFocusOnIndex(Math.max(0, Math.min(hint, n - 1)), true);
+                });
+            } else {
+                keepDrawerOpenOnResume = false;
+                if (d2 != null) d2.forceHide();
+                RecyclingShelfView sh = shelf;
+                if (sh != null) {
+                    resetHomeAlpha();   // app may have launched mid close-fade — clear leftover alpha
+                    sh.setVisibility(View.VISIBLE);
+                    List<AppInfo> vis = buildVisibleList();
+                    pushHomeRow(sh, vis, effectiveHomeCount(vis.size()));
+                }
             }
         }
+        // Defensive: the flag is consumed inside the block above whenever the
+        // drawer was open at pause (the only way it gets set). Clear it
+        // unconditionally so an unpaired set (e.g. the rare ROM where the
+        // system dialog never actually paused us) can never carry into a
+        // later, unrelated resume and wrongly keep the drawer open.
+        keepDrawerOpenOnResume = false;
         RecyclingShelfView s = shelf;
-        if (s != null) {
+        if (s != null && !drawerKeptOpen) {
             int saved = prefs.getInt(KEY_SCROLL_IDX, 0);
             if (!appList.isEmpty()) {
                 // Clamp against the shelf's currently-displayed size so a
@@ -4608,9 +4655,16 @@ public class LauncherActivity extends Activity {
 
         void triggerUninstall() {
             AppInfo app = (dragIndex >= 0 && dragIndex < displayed.size()) ? displayed.get(dragIndex) : null;
-            exitReorderMode(false);
-            LauncherActivity.this.closeDrawer();   // return to home before the system dialog
-            if (app != null) LauncherActivity.this.doUninstall(app);
+            int idx = dragIndex;
+            exitReorderMode(false);   // dismiss the context menu, but keep the drawer open
+            if (app == null) return;
+            // Stay in the drawer on return (mirrors Hide). The uninstall dialog
+            // pauses us; onResume keeps the drawer open and the package-removed
+            // reconcile re-filters its list in place. Only arm the keep-open
+            // flag if the system dialog actually launches (else we'd never
+            // pause/resume to clear it).
+            LauncherActivity.this.pendingDrawerFocusIdx = Math.max(0, idx);
+            LauncherActivity.this.keepDrawerOpenOnResume = LauncherActivity.this.doUninstall(app);
         }
         void triggerHide() {
             int idx = dragIndex;
@@ -4622,9 +4676,13 @@ public class LauncherActivity extends Activity {
         }
         void triggerAppInfo() {
             AppInfo app = (dragIndex >= 0 && dragIndex < displayed.size()) ? displayed.get(dragIndex) : null;
-            exitReorderMode(false);
-            LauncherActivity.this.closeDrawer();
-            if (app != null) LauncherActivity.this.doAppInfo(app);
+            int idx = dragIndex;
+            exitReorderMode(false);   // dismiss the context menu, but keep the drawer open
+            if (app == null) return;
+            // App-info opens the system details screen (pauses us); come back
+            // into the drawer rather than the home screen, same as Uninstall.
+            LauncherActivity.this.pendingDrawerFocusIdx = Math.max(0, idx);
+            LauncherActivity.this.keepDrawerOpenOnResume = LauncherActivity.this.doAppInfo(app);
         }
 
         // ── DrawerCell ─────────────────────────────────────────────────────
@@ -6414,9 +6472,9 @@ public class LauncherActivity extends Activity {
         android.graphics.drawable.GradientDrawable qrPlate =
                 new android.graphics.drawable.GradientDrawable();
         qrPlate.setColor(0xFFFFFFFF);
-        qrPlate.setCornerRadius(dp(8));
+        qrPlate.setCornerRadius(dp(16));
         qrImg.setBackground(qrPlate);
-        qrImg.setPadding(dp(6), dp(6), dp(6), dp(6));
+        qrImg.setPadding(dp(10), dp(10), dp(10), dp(10));
         int qrSz = dp(216);
         qr.addView(qrImg, new android.widget.LinearLayout.LayoutParams(qrSz, qrSz));
 
@@ -6517,7 +6575,15 @@ public class LauncherActivity extends Activity {
 
     /** A small Ko-fi-style coffee cup, drawn into a bitmap (no asset). */
     private View makeKofiIcon() {
-        int s = Math.max(1, dp(22));
+        ImageView iv = new ImageView(this);
+        iv.setImageBitmap(kofiCupBitmap(Math.max(1, dp(22)), 0xCCFFFFFF));   // white steam over the dark row
+        return iv;
+    }
+
+    /** Draw the Ko-fi coffee cup into an {@code s × s} bitmap. {@code steam}
+     *  is the steam-line colour so the cup reads on both the dark About row
+     *  (light steam) and the white QR centre plate (red steam). */
+    private Bitmap kofiCupBitmap(int s, int steam) {
         Bitmap b = Bitmap.createBitmap(s, s, Bitmap.Config.ARGB_8888);
         android.graphics.Canvas c = new android.graphics.Canvas(b);
         Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -6535,14 +6601,34 @@ public class LauncherActivity extends Activity {
                 new android.graphics.RectF(s * 0.58f, s * 0.48f, s * 0.84f, s * 0.78f);
         c.drawArc(handle, -70f, 140f, false, p);
         // Steam.
-        p.setColor(0xCCFFFFFF);
+        p.setColor(steam);
         p.setStrokeWidth(s * 0.05f);
         p.setStrokeCap(Paint.Cap.ROUND);
         c.drawLine(s * 0.30f, s * 0.34f, s * 0.30f, s * 0.14f, p);
         c.drawLine(s * 0.46f, s * 0.34f, s * 0.46f, s * 0.14f, p);
-        ImageView iv = new ImageView(this);
-        iv.setImageBitmap(b);
-        return iv;
+        return b;
+    }
+
+    /** Centre-logo bitmap for an About QR, or {@code null} (plain modern code)
+     *  when none is available. Ko-fi → the coffee cup; GitHub → the octicon
+     *  mark vector. Wrapped so a missing/garbled vector can never break the QR
+     *  — the code just renders without a logo. */
+    private Bitmap aboutQrLogo(int which) {
+        try {
+            int s = Math.max(1, dp(56));
+            if (which == ABOUT_ROW_KOFI) {
+                return kofiCupBitmap(s, 0xFFFF5E5B);   // red steam reads on the white plate
+            }
+            Drawable d = getDrawable(R.drawable.logo_github);
+            if (d == null) return null;
+            Bitmap b = Bitmap.createBitmap(s, s, Bitmap.Config.ARGB_8888);
+            android.graphics.Canvas c = new android.graphics.Canvas(b);
+            d.setBounds(0, 0, s, s);
+            d.draw(c);
+            return b;
+        } catch (Throwable ignored) {
+            return null;
+        }
     }
 
     private void showAboutOverlay() {
@@ -6613,7 +6699,11 @@ public class LauncherActivity extends Activity {
     private void showAboutQr(int which) {
         String url = (which == ABOUT_ROW_KOFI) ? ABOUT_KOFI_URL : ABOUT_GITHUB_RELEASES;
         aboutQrUrl = url;
-        Bitmap bmp = QrCode.render(url, dp(204), 0xFF101014, 0xFFFFFFFF);
+        // Modern rounded code with the matching brand mark centred. Falls back
+        // to a plain modern code if the logo can't be built; renderStyled keeps
+        // level-M error correction, which recovers the small centre plate.
+        Bitmap bmp = QrCode.renderStyled(url, dp(204), 0xFF101014, 0xFFFFFFFF,
+                aboutQrLogo(which), 0.22f);
         if (aboutQrImage != null) aboutQrImage.setImageBitmap(bmp);
         if (aboutQrCaption != null) {
             aboutQrCaption.setText(which == ABOUT_ROW_KOFI
@@ -7479,7 +7569,11 @@ public class LauncherActivity extends Activity {
         addPickerChip(strip, getString(R.string.keymap_not_assigned), null, true);
         for (int i = 0; i < keymapPickerApps.size(); i++) {
             AppInfo a = keymapPickerApps.get(i);
-            Bitmap b = (iconCache != null) ? iconCache.get(a.packageName) : null;
+            // TV inputs have no app icon in the cache — draw a small input
+            // glyph so the chip isn't blank. Apps use their cached round icon.
+            Bitmap b = (a.tvInputId != null)
+                    ? IconRenderer.generateInputGlyphIcon(dp(20), density)
+                    : ((iconCache != null) ? iconCache.get(a.packageName) : null);
             addPickerChip(strip, a.label, b, false);
         }
     }
@@ -7930,7 +8024,10 @@ public class LauncherActivity extends Activity {
                 (a, b) -> String.CASE_INSENSITIVE_ORDER.compare(a.label, b.label));
         for (int i = 0; i < hideListApps.size(); i++) {
             AppInfo a = hideListApps.get(i);
-            Bitmap b = (iconCache != null) ? iconCache.get(a.packageName) : null;
+            // TV inputs have no cached app icon — use a small input glyph.
+            Bitmap b = (a.tvInputId != null)
+                    ? IconRenderer.generateInputGlyphIcon(dp(22), density)
+                    : ((iconCache != null) ? iconCache.get(a.packageName) : null);
             addHideRow(strip, a.label, b);
         }
         if (hideListApps.isEmpty()) {
@@ -8099,8 +8196,14 @@ public class LauncherActivity extends Activity {
         int idx = keymapHideIdx;
         if (idx < 0 || idx >= hideListApps.size()) return;
         String pkg = hideListApps.get(idx).packageName;
+        AppInfo unhidden = hideListApps.get(idx);
         hiddenApps.remove(pkg);
         saveHiddenApps();
+        // Land the returning app at the FRONT of the drawer rather than letting
+        // it reclaim its old home-row slot (which would bump a current favourite
+        // down into the drawer). Keeps the user's visible home row exactly as it
+        // is and treats unhide as "bring it back into the drawer".
+        repositionUnhiddenIntoDrawer(unhidden);
         keymapHideDirty = true;
         // Rebuild the "hidden only" list (the unhidden app is now gone) and
         // clamp the cursor to the new, shorter list.
@@ -8109,6 +8212,35 @@ public class LauncherActivity extends Activity {
         keymapHideIdx     = n > 0 ? Math.min(idx, n - 1) : -1;
         keymapHideLastIdx = -1;   // force a full repaint
         refreshHideStrip();
+    }
+
+    /** Re-place a just-unhidden app at the FIRST drawer slot (immediately past
+     *  the home segment) instead of leaving it at its old index — which, if
+     *  that index fell inside the home row, would push a current favourite out
+     *  to the drawer. The home row keeps exactly the apps it shows now; the
+     *  returning app joins the top of the drawer.
+     *
+     *  <p>Positional model (see {@link HomeDrawerModel}): the home row is the
+     *  first {@code effectiveHomeCount} visible apps. We remove the app and
+     *  re-insert it at the {@link #appList} index whose visible rank equals
+     *  {@code hc}, so its new visible rank is exactly the first drawer slot.
+     *  When there aren't enough visible apps to fill the home row it simply
+     *  lands at the end (still in the home row — unavoidable, and correct).
+     *  The new order is persisted; the shelf/drawer rebuild on the hide-manager
+     *  close (keymapHideDirty) renders it. */
+    private void repositionUnhiddenIntoDrawer(AppInfo app) {
+        if (app == null) return;
+        int hc = effectiveHomeCount(countVisible(appList));   // app is already un-hidden here
+        if (!appList.remove(app)) return;
+        int seen = 0, insertAt = appList.size();
+        for (int i = 0, n = appList.size(); i < n; i++) {
+            if (!hiddenApps.contains(appList.get(i).packageName)) {
+                if (seen == hc) { insertAt = i; break; }
+                seen++;
+            }
+        }
+        appList.add(insertAt, app);
+        saveOrder();
     }
 
     /** Auto-scroll the vertical list so the selected row stays in view with

--- a/LauncherV15/app/src/main/java/com/bare/launcher/QrCode.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/QrCode.java
@@ -1,7 +1,10 @@
 package com.bare.launcher;
 
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.RectF;
 
 import java.nio.charset.StandardCharsets;
 
@@ -84,6 +87,105 @@ final class QrCode {
     /** Convenience: black-on-white render. */
     static Bitmap render(String text, int targetPx) {
         return render(text, targetPx, Color.BLACK, Color.WHITE);
+    }
+
+    /**
+     * Modern, rounded render of {@code text}: circular data dots and rounded
+     * finder "eyes" on a light background, with an optional logo centred in a
+     * rounded light plate. Anti-aliased via {@link Canvas} (the plain
+     * {@link #render} stays a fast per-pixel path for any non-decorative use).
+     *
+     * <p>The centre logo overlaps a few modules, but level-M error correction
+     * (~15 %) easily recovers a plate of this size ({@code logoFrac} ≈ 0.22 of
+     * the code width → ~5 % area), so the code still scans. Returns
+     * {@code null} if the text doesn't fit versions 1–10 at level M.
+     *
+     * @param logo      optional centre logo bitmap (already coloured); may be
+     *                  {@code null} for a plain modern code.
+     * @param logoFrac  logo-plate width as a fraction of the code (excluding
+     *                  the quiet zone); clamped to {@code [0, 0.28]}.
+     */
+    static Bitmap renderStyled(String text, int targetPx, int dark, int light,
+                               Bitmap logo, float logoFrac) {
+        boolean[][] modules = encode(text);
+        if (modules == null) return null;
+        int size = modules.length;
+        final int quiet = 4;
+        int total = size + quiet * 2;
+        int scale = Math.max(1, targetPx / total);
+        int dim = total * scale;
+
+        Bitmap bmp = Bitmap.createBitmap(dim, dim, Bitmap.Config.ARGB_8888);
+        Canvas c = new Canvas(bmp);
+        c.drawColor(light);
+
+        Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+        p.setColor(dark);
+        p.setStyle(Paint.Style.FILL);
+
+        final int off = quiet * scale;     // pixel origin of module (0,0)
+        final float r = scale * 0.5f;      // data-dot radius (inscribed → dots just touch)
+
+        // Data dots — every dark module except the three finder patterns,
+        // which are drawn as stylised rounded eyes below.
+        for (int my = 0; my < size; my++) {
+            for (int mx = 0; mx < size; mx++) {
+                if (!modules[my][mx] || inFinder(mx, my, size)) continue;
+                float cx = off + mx * scale + scale * 0.5f;
+                float cy = off + my * scale + scale * 0.5f;
+                c.drawCircle(cx, cy, r, p);
+            }
+        }
+
+        // Rounded finder eyes (top-left, top-right, bottom-left).
+        drawFinder(c, off,                    off,                    scale, dark, light);
+        drawFinder(c, off + (size - 7) * scale, off,                  scale, dark, light);
+        drawFinder(c, off,                    off + (size - 7) * scale, scale, dark, light);
+
+        // Centre logo on a rounded light plate.
+        if (logo != null && logoFrac > 0f && !logo.isRecycled()) {
+            float f = Math.min(0.28f, logoFrac);
+            float codePx = size * scale;
+            float plate  = codePx * f;
+            float pad    = plate * 0.16f;
+            float cxp = off + codePx / 2f, cyp = off + codePx / 2f;
+            RectF pr = new RectF(cxp - plate / 2f, cyp - plate / 2f,
+                                 cxp + plate / 2f, cyp + plate / 2f);
+            Paint pp = new Paint(Paint.ANTI_ALIAS_FLAG);
+            pp.setColor(light); pp.setStyle(Paint.Style.FILL);
+            float rad = plate * 0.26f;
+            c.drawRoundRect(pr, rad, rad, pp);
+            RectF lr = new RectF(pr.left + pad, pr.top + pad, pr.right - pad, pr.bottom - pad);
+            Paint ip = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
+            c.drawBitmap(logo, null, lr, ip);
+        }
+        return bmp;
+    }
+
+    /** True when module ({@code mx},{@code my}) lies inside one of the three
+     *  7×7 finder patterns (drawn as stylised eyes, not data dots). */
+    private static boolean inFinder(int mx, int my, int size) {
+        return (mx < 7 && my < 7)
+            || (mx >= size - 7 && my < 7)
+            || (mx < 7 && my >= size - 7);
+    }
+
+    /** Draw one rounded finder eye at pixel origin ({@code ox},{@code oy}):
+     *  a 7-module dark rounded square, a 5-module light gap, and a 3-module
+     *  dark rounded centre — the modern "rounded eye" look. */
+    private static void drawFinder(Canvas c, float ox, float oy, int scale, int dark, int light) {
+        Paint p = new Paint(Paint.ANTI_ALIAS_FLAG);
+        p.setStyle(Paint.Style.FILL);
+        float m = scale;
+        p.setColor(dark);
+        RectF outer = new RectF(ox, oy, ox + 7 * m, oy + 7 * m);
+        c.drawRoundRect(outer, m * 1.6f, m * 1.6f, p);
+        p.setColor(light);
+        RectF gap = new RectF(ox + m, oy + m, ox + 6 * m, oy + 6 * m);
+        c.drawRoundRect(gap, m * 1.2f, m * 1.2f, p);
+        p.setColor(dark);
+        RectF ctr = new RectF(ox + 2 * m, oy + 2 * m, ox + 5 * m, oy + 5 * m);
+        c.drawRoundRect(ctr, m * 0.9f, m * 0.9f, p);
     }
 
     // ── Error-correction tables (level M only, versions 1–10) ────────────

--- a/LauncherV15/app/src/main/java/com/bare/launcher/ReorderHost.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/ReorderHost.java
@@ -34,4 +34,10 @@ interface ReorderHost {
 
     /** The user activated the Move row (confirm reorder). */
     void onMenuMove();
+
+    /** {@code true} when the app the menu is currently acting on is a TV
+     *  input (HDMI/AV/…). The activity uses this to suppress the Uninstall
+     *  and App-info rows — an input is not an installed package — while
+     *  keeping Move and Hide. */
+    boolean menuAppIsInput();
 }

--- a/LauncherV15/app/src/main/java/com/bare/launcher/TvInputs.java
+++ b/LauncherV15/app/src/main/java/com/bare/launcher/TvInputs.java
@@ -1,0 +1,131 @@
+package com.bare.launcher;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.media.tv.TvContract;
+import android.media.tv.TvInputInfo;
+import android.media.tv.TvInputManager;
+import android.net.Uri;
+import android.os.Bundle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Surfaces the device's hardware TV inputs (HDMI 1/2/3, AV / composite,
+ * component, S-Video, …) as launcher entries via the platform TV Input
+ * Framework (TIF) — the same mechanism stock TV launchers use.
+ *
+ * <h3>Why this needs no special permission</h3>
+ * Enumerating inputs ({@link TvInputManager#getTvInputList()}) and switching
+ * to one (an {@link Intent#ACTION_VIEW} on the input's passthrough channel
+ * URI, handled by the system Live-TV app) are both available to an ordinary
+ * app. There is no privileged / system permission involved; the manifest only
+ * declares the {@code android.software.live_tv} feature as <em>not</em>
+ * required so the APK still installs everywhere.
+ *
+ * <h3>Device support &amp; graceful degradation</h3>
+ * Inputs only exist on hardware that actually has them — real Android TVs
+ * with HDMI-in ports, and some TV boxes. Streaming sticks / Chromecast / most
+ * cheap boxes / Fire TV expose no passthrough inputs, so {@link #enumerate}
+ * returns an empty list and the launcher behaves exactly as before (no tiles,
+ * no behaviour change). Every TIF call is wrapped so a misbehaving ROM can
+ * never destabilise the shelf — failure simply yields "no inputs".
+ *
+ * <h3>Cost</h3>
+ * {@link #enumerate} is a single binder query, run once per app-list scan on
+ * the background app executor (never the UI thread). There is no callback, no
+ * polling, and no steady-state cost. The generated input tile is cached in the
+ * normal banner cache like any app tile.
+ */
+final class TvInputs {
+
+    private TvInputs() { /* no instances */ }
+
+    /**
+     * Enumerate the device's passthrough TV inputs as {@link AppInfo} entries
+     * (one per HDMI / AV / component port). Returns an empty list — never
+     * {@code null} — on any device without TIF inputs or on any failure.
+     *
+     * <p>Safe to call off the main thread; it is invoked from the
+     * {@code loadApps} PM scan on the app executor.
+     */
+    static List<AppInfo> enumerate(Context ctx) {
+        List<AppInfo> out = new ArrayList<>();
+        if (ctx == null) return out;
+        try {
+            TvInputManager tim =
+                    (TvInputManager) ctx.getSystemService(Context.TV_INPUT_SERVICE);
+            if (tim == null) return out;                 // no TIF on this device
+            List<TvInputInfo> inputs = tim.getTvInputList();
+            if (inputs == null) return out;
+            for (TvInputInfo info : inputs) {
+                if (info == null) continue;
+                // Only passthrough inputs (HDMI / AV / component / …) are a
+                // "switch to this source" tile. Tuner / app inputs are
+                // channel-based and are intentionally skipped.
+                if (!info.isPassthroughInput()) continue;
+                // Respect OEM-hidden inputs (e.g. an unwired internal port).
+                try { if (info.isHidden(ctx)) continue; } catch (Throwable ignored) { /* keep */ }
+                String id = info.getId();
+                if (id == null || id.isEmpty()) continue;
+                out.add(AppInfo.tvInput(id, label(ctx, info)));
+            }
+        } catch (Throwable ignored) {
+            // Any TIF failure → behave as if there are no inputs. The shelf
+            // is never destabilised by a flaky TV-input service.
+            out.clear();
+        }
+        return out;
+    }
+
+    /** Best user-visible label for an input: the OEM custom label ("HDMI 1")
+     *  when present, then the generic input label, then a type-derived
+     *  fallback. */
+    private static String label(Context ctx, TvInputInfo info) {
+        try {
+            CharSequence custom = info.loadCustomLabel(ctx);
+            if (custom != null && custom.length() > 0) return custom.toString();
+        } catch (Throwable ignored) { /* fall through */ }
+        try {
+            CharSequence lbl = info.loadLabel(ctx);
+            if (lbl != null && lbl.length() > 0) return lbl.toString();
+        } catch (Throwable ignored) { /* fall through */ }
+        switch (info.getType()) {
+            case TvInputInfo.TYPE_HDMI:         return "HDMI";
+            case TvInputInfo.TYPE_COMPONENT:    return "Component";
+            case TvInputInfo.TYPE_COMPOSITE:    return "AV";
+            case TvInputInfo.TYPE_SVIDEO:       return "S-Video";
+            case TvInputInfo.TYPE_SCART:        return "SCART";
+            case TvInputInfo.TYPE_VGA:          return "VGA";
+            case TvInputInfo.TYPE_DVI:          return "DVI";
+            case TvInputInfo.TYPE_DISPLAY_PORT: return "DisplayPort";
+            case TvInputInfo.TYPE_TUNER:        return "Tuner";
+            default:                            return "Input";
+        }
+    }
+
+    /**
+     * Switch to the given passthrough input by handing the system Live-TV app
+     * an {@link Intent#ACTION_VIEW} on the input's channel URI. Returns
+     * {@code true} if a handler was found and launched, {@code false} if no
+     * app on the device can switch inputs (caller then shows a toast).
+     *
+     * @param anim optional launch-animation bundle (scale-up from the tile);
+     *             may be {@code null}.
+     */
+    static boolean launch(Activity host, String inputId, Bundle anim) {
+        if (host == null || inputId == null || inputId.isEmpty()) return false;
+        try {
+            Uri uri = TvContract.buildChannelUriForPassthroughInput(inputId);
+            Intent i = new Intent(Intent.ACTION_VIEW, uri)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            if (i.resolveActivity(host.getPackageManager()) == null) return false;
+            host.startActivity(i, anim);
+            return true;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+}

--- a/LauncherV15/app/src/main/res/drawable/logo_github.xml
+++ b/LauncherV15/app/src/main/res/drawable/logo_github.xml
@@ -1,0 +1,12 @@
+<!-- GitHub "mark" (Octocat silhouette), the standard 16-unit octicon path.
+     Plain platform VectorDrawable — no third-party dependency. Rendered into
+     the centre of the GitHub About QR. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <path
+        android:fillColor="#FF181717"
+        android:pathData="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+</vector>

--- a/LauncherV15/app/src/main/res/values/strings.xml
+++ b/LauncherV15/app/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="toast_no_settings">Cannot open settings</string>
     <string name="toast_no_app_info">Cannot open app info</string>
     <string name="toast_app_unavailable">App not available</string>
+    <string name="toast_input_unavailable">Can\'t switch to this input</string>
     <string name="toast_no_file_picker">No file picker available</string>
     <string name="toast_no_browser">No browser available to open the link</string>
     <string name="toast_wallpaper_load_failed">Could not load wallpaper</string>


### PR DESCRIPTION
Hardware TV inputs from the TV Input Framework now appear as first-class tiles (HDMI 1, HDMI 2, AV, ...) that sort, place, move, hide, and bind to remote keys exactly like apps; opening one switches to that passthrough source via TvContract. No permission required (live_tv feature declared not-required); a clean no-op on devices with no inputs.

Model: AppInfo gains a tvInputId (synthetic 'tvinput://<id>' key); new TvInputs helper enumerates (off the UI thread, in queryApps) and launches; IconRenderer.generateInputTile draws a self-identifying glyph+label tile (local paints, thread-safe). Inputs are excluded from the cold-start AppListCache and re-enumerated each scan; live order still records placement.

Menu: input tiles show only Move + Hide. The per-cell UP/DOWN nav is centralised in menuNavSel (provably identical for normal apps) and skips the hidden Uninstall/App-info rows; ReorderHost.menuAppIsInput drives it, with defensive guards in the uninstall/app-info paths.

No steady-state or per-frame cost: one binder enumeration per scan, tiles cached like app tiles, no callbacks/polling.